### PR TITLE
Set env var to tag plugin identify for metrics

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/DeployTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/DeployTask.java
@@ -52,6 +52,7 @@ public class DeployTask extends DefaultTask {
   public void deployAction() throws AppEngineException {
     CloudSdk sdk = new CloudSdk.Builder()
         .sdkPath(cloudSdkHome)
+        .appCommandMetricsEnvironment("app-gradle-plugin")
         .exitListener(new NonZeroExceptionExitListener())
         .build();
     AppEngineDeployment deploy = new CloudSdkAppEngineDeployment(sdk);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerRunTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerRunTask.java
@@ -51,6 +51,7 @@ public class DevAppServerRunTask extends DefaultTask {
   public void runAction() throws AppEngineException {
     CloudSdk sdk = new CloudSdk.Builder()
         .sdkPath(cloudSdkHome)
+        .appCommandMetricsEnvironment("app-gradle-plugin")
         .exitListener(new NonZeroExceptionExitListener())
         .build();
     CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(sdk);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerStartTask.java
@@ -59,6 +59,7 @@ public class DevAppServerStartTask extends DefaultTask {
     ProcessOutputLineListener lineListener = new FileOutputLineListener(logFile);
     CloudSdk sdk = new CloudSdk.Builder()
         .sdkPath(cloudSdkHome)
+        .appCommandMetricsEnvironment("app-gradle-plugin")
         .async(true)
         .runDevAppServerWait(10)
         .addStdErrLineListener(lineListener)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/DevAppServerStopTask.java
@@ -46,7 +46,10 @@ public class DevAppServerStopTask extends DefaultTask {
 
   @TaskAction
   public void stopAction() throws AppEngineException {
-    CloudSdk sdk = new CloudSdk.Builder().sdkPath(cloudSdkHome).build();
+    CloudSdk sdk = new CloudSdk.Builder()
+        .sdkPath(cloudSdkHome)
+        .appCommandMetricsEnvironment("app-gradle-plugin")
+        .build();
     CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(sdk);
     server.stop(runConfig);
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/StageStandardTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/StageStandardTask.java
@@ -39,22 +39,23 @@ public class StageStandardTask extends DefaultTask {
 
   @Nested
   public StageStandardModel getStagingConfig() {
-                                               return stagingConfig;
-                                                                    }
+      return stagingConfig;
+  }
 
   public void setStagingConfig(StageStandardModel stagingConfig) {
     this.stagingConfig = stagingConfig;
   }
 
   public void setCloudSdkHome(File cloudSdkHome) {
-                                                 this.cloudSdkHome = cloudSdkHome;
-                                                                                  }
+      this.cloudSdkHome = cloudSdkHome;
+  }
 
   @TaskAction
   public void stageAction() throws AppEngineException {
     getProject().delete(stagingConfig.getStagingDirectory());
     CloudSdk sdk = new CloudSdk.Builder()
         .sdkPath(cloudSdkHome)
+        .appCommandMetricsEnvironment("app-gradle-plugin")
         .exitListener(new NonZeroExceptionExitListener())
         .build();
     CloudSdkAppEngineStandardStaging staging = new CloudSdkAppEngineStandardStaging(sdk);


### PR DESCRIPTION
In relation to #3.

I'd like to set this now so that we don't forget it before the next release. How about "app-gradle-plugin"?

Note: we still need to set ENVIRONMENT_VERSION.
