### PR TITLE
Add appengineShowConfiguration task

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/AppEngineFlexiblePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/AppEngineFlexiblePlugin.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine;
 import com.google.cloud.tools.gradle.appengine.model.AppEngineFlexibleExtension;
 import com.google.cloud.tools.gradle.appengine.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.task.DeployTask;
+import com.google.cloud.tools.gradle.appengine.task.ShowConfigurationTask;
 import com.google.cloud.tools.gradle.appengine.task.StageFlexibleTask;
 
 import org.gradle.api.Action;
@@ -42,6 +43,8 @@ public class AppEngineFlexiblePlugin implements Plugin<Project> {
 
   private static final String STAGE_TASK_NAME = "appengineStage";
   private static final String DEPLOY_TASK_NAME = "appengineDeploy";
+  private static final String SHOW_CONFIG_TASK_NAME = "appengineShowConfiguration";
+
   private static final String APP_ENGINE_FLEXIBLE_TASK_GROUP = "App Engine flexible environment";
   private static final String STAGED_APP_DIR_NAME = "staged-app";
 
@@ -57,6 +60,7 @@ public class AppEngineFlexiblePlugin implements Plugin<Project> {
 
     createStageTask();
     createDeployTask();
+    createShowConfigurationTask();
   }
 
   private void createPluginExtension() {
@@ -132,5 +136,24 @@ public class AppEngineFlexiblePlugin implements Plugin<Project> {
         });
       }
     });
+  }
+
+  private void createShowConfigurationTask() {
+    project.getTasks().create(SHOW_CONFIG_TASK_NAME, ShowConfigurationTask.class,
+        new Action<ShowConfigurationTask>() {
+          @Override
+          public void execute(final ShowConfigurationTask showConfigurationTask) {
+            showConfigurationTask.setGroup(APP_ENGINE_FLEXIBLE_TASK_GROUP);
+            showConfigurationTask.setDescription("Show current App Engine plugin configuration");
+
+            project.afterEvaluate(new Action<Project>() {
+              @Override
+              public void execute(Project project) {
+                showConfigurationTask.setExtensionClass(AppEngineFlexibleExtension.class);
+                showConfigurationTask.setExtensionInstance(extension);
+              }
+            });
+          }
+        });
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPlugin.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine;
 import com.google.cloud.tools.gradle.appengine.model.AppEngineStandardExtension;
 import com.google.cloud.tools.gradle.appengine.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.task.DeployTask;
+import com.google.cloud.tools.gradle.appengine.task.ShowConfigurationTask;
 import com.google.cloud.tools.gradle.appengine.task.DevAppServerRunTask;
 import com.google.cloud.tools.gradle.appengine.task.DevAppServerStartTask;
 import com.google.cloud.tools.gradle.appengine.task.DevAppServerStopTask;
@@ -55,6 +56,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
   private static final String START_TASK_NAME = "appengineStart";
   private static final String STOP_TASK_NAME = "appengineStop";
   private static final String DEPLOY_TASK_NAME = "appengineDeploy";
+  private static final String SHOW_CONFIG_TASK_NAME = "appengineShowConfiguration";
 
   private static final String EXPLODED_APP_DIR_NAME = "exploded-app";
   private static final String STAGED_APP_DIR_NAME = "staged-app";
@@ -74,6 +76,8 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
     createStageTask();
     createRunTasks();
     createDeployTask();
+
+    createShowConfigurationTask();
   }
 
   private void createPluginExtension() {
@@ -233,5 +237,24 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
         });
       }
     });
+  }
+
+  private void createShowConfigurationTask() {
+    project.getTasks().create(SHOW_CONFIG_TASK_NAME, ShowConfigurationTask.class,
+        new Action<ShowConfigurationTask>() {
+          @Override
+          public void execute(final ShowConfigurationTask showConfigurationTask) {
+            showConfigurationTask.setGroup(APP_ENGINE_STANDARD_TASK_GROUP);
+            showConfigurationTask.setDescription("Show current App Engine plugin configuration");
+
+            project.afterEvaluate(new Action<Project>() {
+              @Override
+              public void execute(Project project) {
+                showConfigurationTask.setExtensionClass(AppEngineStandardExtension.class);
+                showConfigurationTask.setExtensionInstance(extension);
+              }
+            });
+          }
+        });
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/task/ShowConfigurationTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/task/ShowConfigurationTask.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.task;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Task to print the appengine configuration closure
+ */
+public class ShowConfigurationTask extends DefaultTask {
+
+  // require extensionClass because gradle creates a decorated_class extension instance
+  private Class<?> extensionClass;
+  private Object extensionInstance;
+
+  @Input
+  public Class<?> getExtensionClass() {
+    return extensionClass;
+  }
+
+  public void setExtensionClass(Class<?> extension) {
+    this.extensionClass = extension;
+  }
+
+  @Input
+  public Object getExtensionInstance() {
+    return extensionInstance;
+  }
+
+  public void setExtensionInstance(Object extensionInstance) {
+    this.extensionInstance = extensionInstance;
+  }
+
+  @TaskAction
+  public void showConfiguration() throws IllegalAccessException {
+    if (!extensionClass.isInstance(extensionInstance)) {
+      throw new GradleException(extensionInstance.getClass() + " is not " + extensionClass.getName());
+    }
+    // this is hardcoded in
+    getLogger().lifecycle("appengine {");
+    getLogger().lifecycle(getAllFields(extensionClass, extensionInstance));
+    getLogger().lifecycle("}");
+  }
+
+  @VisibleForTesting
+  static String getAllFields(Class root, Object instance) throws IllegalAccessException {
+    StringBuilder result = new StringBuilder("");
+    for (Field field : root.getDeclaredFields()) {
+      result.append(getAllFields(field, 1, instance));
+    }
+    return result.toString();
+  }
+
+  // recursive
+  private static String getAllFields(Field root, int depth, Object instance) throws IllegalAccessException {
+    StringBuilder result = new StringBuilder("");
+    root.setAccessible(true);
+    if (!root.getType().isPrimitive() && root.getType().getPackage().getName().equals("com.google.cloud.tools.gradle.appengine.model")) {
+      result.append(Strings.repeat(" ", depth)).append(root.getName()).append(" {\n");
+      for (Field child : root.getType().getDeclaredFields()) {
+        result.append(getAllFields(child, depth + 1, root.get(instance)));
+      }
+      result.append(Strings.repeat(" ", depth)).append("}\n");
+    }
+    else {
+      result.append(Strings.repeat(" ", depth))
+          .append("(")
+          .append(root.getType().getSimpleName())
+          .append(getGenericTypeData(root))
+          .append(") ")
+          .append(root.getName())
+          .append(" = ")
+          .append(root.get(instance))
+          .append("\n");
+    }
+    return result.toString();
+  }
+
+  private static String getGenericTypeData(Field f) {
+    Type genericType = f.getGenericType();
+    List<String> types = Lists.newArrayList();
+    if (genericType != null && genericType instanceof ParameterizedType) {
+      for (Type t :((ParameterizedType)genericType).getActualTypeArguments()) {
+        types.add(((Class) t).getSimpleName());
+      }
+    }
+    return (types.size() > 0) ? "<" + Joiner.on(", ").join(types) + ">" : "";
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestChild.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestChild.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.model;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestChild {
+  public List<String> member1 = Collections.singletonList("hello");
+  public int member2 = 5;
+  public List<String> member3;
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestGrandParent.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestGrandParent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.model;
+
+public class TestGrandParent {
+  private TestParent parent = new TestParent();
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestParent.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/model/TestParent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.model;
+
+import java.util.Map;
+
+public class TestParent {
+  private Map<String, Integer> member1;
+  private TestChild child = new TestChild();
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/task/ShowConfigurationTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/task/ShowConfigurationTaskTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.task;
+
+import com.google.cloud.tools.gradle.appengine.model.AppEngineFlexibleExtension;
+import com.google.cloud.tools.gradle.appengine.model.AppEngineStandardExtension;
+import com.google.cloud.tools.gradle.appengine.model.TestGrandParent;
+
+import org.gradle.internal.impldep.org.testng.Assert;
+import org.junit.Test;
+
+/**
+ * Test ShowConfigurationTask
+ */
+public class ShowConfigurationTaskTest {
+  private static String expected = ""
+      + " parent {\n"
+      + "  (Map<String, Integer>) member1 = null\n"
+      + "  child {\n"
+      + "   (List<String>) member1 = [hello]\n"
+      + "   (int) member2 = 5\n"
+      + "   (List<String>) member3 = null\n"
+      + "  }\n"
+      + " }\n";
+
+  @Test
+  public void testGetAllFields() throws IllegalAccessException {
+    String result = ShowConfigurationTask.getAllFields(TestGrandParent.class, new TestGrandParent());
+    Assert.assertEquals(result, expected);
+  }
+
+  @Test
+  public void testGetAllFields_AppEngineShowWithoutException() throws IllegalAccessException {
+    ShowConfigurationTask
+        .getAllFields(AppEngineFlexibleExtension.class, new AppEngineFlexibleExtension());
+    ShowConfigurationTask
+        .getAllFields(AppEngineStandardExtension.class, new AppEngineStandardExtension());
+  }
+}


### PR DESCRIPTION
This prints out the appengine extension, the types
of all the parameters and their values after project
evaluation.

Because we can't get a description from the model anymore,
we have to write a custom task to do it.