### PR TITLE
Allow Strings to be passed to parameters that expect Files

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePlugin.java
@@ -64,8 +64,8 @@ public class AppEngineCorePlugin implements Plugin<Project> {
 
   private void createExtensions() {
     extension = project.getExtensions().create(APPENGINE_EXTENSION, AppEngine.class);
-    deployExtension = ((ExtensionAware) extension).getExtensions().create(DEPLOY_EXTENSION, Deploy.class);
-    toolsExtension = ((ExtensionAware) extension).getExtensions().create(TOOLS_EXTENSION, Tools.class);
+    deployExtension = ((ExtensionAware) extension).getExtensions().create(DEPLOY_EXTENSION, Deploy.class, project);
+    toolsExtension = ((ExtensionAware) extension).getExtensions().create(TOOLS_EXTENSION, Tools.class, project);
 
     project.afterEvaluate(new Action<Project>() {
       @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/extension/Deploy.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/extension/Deploy.java
@@ -19,13 +19,20 @@ package com.google.cloud.tools.gradle.appengine.core.extension;
 
 import com.google.cloud.tools.appengine.api.deploy.DeployConfiguration;
 
+import org.gradle.api.Project;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Extension element to define Deployable configurations for App Engine
  */
 public class Deploy implements DeployConfiguration {
+
+  // named gradleProject to disambiguate with deploy parameter "project"
+  private final Project gradleProject;
+
   private String bucket;
   private List<File> deployables;
   private String imageUrl;
@@ -34,6 +41,10 @@ public class Deploy implements DeployConfiguration {
   private String server;
   private Boolean stopPreviousVersion;
   private String version;
+
+  public Deploy(Project gradleProject) {
+    this.gradleProject = gradleProject;
+  }
 
   @Override
   public String getBucket() {
@@ -49,8 +60,8 @@ public class Deploy implements DeployConfiguration {
     return deployables;
   }
 
-  public void setDeployables(List<File> deployables) {
-    this.deployables = deployables;
+  public void setDeployables(Object deployables) {
+    this.deployables = new ArrayList<>(gradleProject.files(deployables).getFiles());
   }
 
   @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/flexible/AppEngineFlexiblePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/flexible/AppEngineFlexiblePlugin.java
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.War;
 
 import java.io.File;
-import java.util.Collections;
 
 /**
  * Plugin definition for App Engine flexible environments
@@ -67,8 +66,8 @@ public class AppEngineFlexiblePlugin implements Plugin<Project> {
 
     File defaultStagedAppDir = new File(project.getBuildDir(), STAGED_APP_DIR_NAME);
 
-    stageExtension = appengine.getExtensions().create(STAGE_EXTENSION, StageFlexible.class, defaultStagedAppDir, project.getRootDir());
-    deploy.setDeployables(Collections.singletonList(new File(defaultStagedAppDir, "app.yaml")));
+    stageExtension = appengine.getExtensions().create(STAGE_EXTENSION, StageFlexible.class, project, defaultStagedAppDir);
+    deploy.setDeployables(new File(defaultStagedAppDir, "app.yaml"));
 
     project.afterEvaluate(new Action<Project>() {
       @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/flexible/extension/StageFlexible.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/flexible/extension/StageFlexible.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine.flexible.extension;
 import com.google.cloud.tools.appengine.api.deploy.StageFlexibleConfiguration;
 import com.google.cloud.tools.gradle.appengine.standard.extension.StageStandard;
 
+import org.gradle.api.Project;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
@@ -32,12 +33,17 @@ import java.io.File;
  */
 public class StageFlexible implements StageFlexibleConfiguration {
 
+  private final Project project;
+
   private File appEngineDirectory;
   private File dockerDirectory;
   private File artifact;
   private File stagingDirectory;
 
-  public StageFlexible(File stagingDirectory, File projectRoot) {
+  public StageFlexible(Project project, File stagingDirectory) {
+    this.project = project;
+    File projectRoot = project.getRootDir();
+
     this.stagingDirectory = stagingDirectory;
     this.appEngineDirectory = new File(projectRoot, "src/main/appengine");
     File dockerOptionalDir = new File(projectRoot, "src/main/docker");
@@ -52,8 +58,8 @@ public class StageFlexible implements StageFlexibleConfiguration {
     return appEngineDirectory;
   }
 
-  public void setAppEngineDirectory(File appEngineDirectory) {
-    this.appEngineDirectory = appEngineDirectory;
+  public void setAppEngineDirectory(Object appEngineDirectory) {
+    this.appEngineDirectory = project.file(appEngineDirectory);
   }
 
   @Override
@@ -63,8 +69,8 @@ public class StageFlexible implements StageFlexibleConfiguration {
     return dockerDirectory;
   }
 
-  public void setDockerDirectory(File dockerDirectory) {
-    this.dockerDirectory = dockerDirectory;
+  public void setDockerDirectory(Object dockerDirectory) {
+    this.dockerDirectory = project.file(dockerDirectory);
   }
 
   @Override
@@ -73,8 +79,8 @@ public class StageFlexible implements StageFlexibleConfiguration {
     return artifact;
   }
 
-  public void setArtifact(File artifact) {
-    this.artifact = artifact;
+  public void setArtifact(Object artifact) {
+    this.artifact = project.file(artifact);
   }
 
   @Override
@@ -83,7 +89,7 @@ public class StageFlexible implements StageFlexibleConfiguration {
     return stagingDirectory;
   }
 
-  public void setStagingDirectory(File stagingDirectory) {
-    this.stagingDirectory = stagingDirectory;
+  public void setStagingDirectory(Object stagingDirectory) {
+    this.stagingDirectory = project.file(stagingDirectory);
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
@@ -62,8 +62,7 @@ public class SourceContextPlugin implements Plugin<Project> {
 
     // create our extension under the root appengine extension
     extension = appengine.getExtensions()
-        .create(SOURCE_CONTEXT_EXTENSION, GenRepoInfoFileExtension.class, project.getBuildDir(),
-            new File(project.getRootDir(), "src"));
+        .create(SOURCE_CONTEXT_EXTENSION, GenRepoInfoFileExtension.class, project);
 
     // wait to read the cloudSdkHome till after project evaluation
     project.afterEvaluate(new Action<Project>() {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/extension/GenRepoInfoFileExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/extension/GenRepoInfoFileExtension.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.gradle.appengine.sourcecontext.extension;
 
 import com.google.cloud.tools.appengine.api.debug.GenRepoInfoFileConfiguration;
 
+import org.gradle.api.Project;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -29,12 +30,15 @@ import java.io.File;
  */
 public class GenRepoInfoFileExtension implements GenRepoInfoFileConfiguration {
 
+  private final Project project;
+
   private final File outputDirectory;
   private File sourceDirectory;
 
-  public GenRepoInfoFileExtension(File buildDir, File sourceRoot) {
-    outputDirectory = new File(buildDir, "sourceContext");
-    sourceDirectory = sourceRoot;
+  public GenRepoInfoFileExtension(Project project) {
+    this.project = project;
+    outputDirectory = new File(project.getBuildDir(), "sourceContext");
+    sourceDirectory = new File(project.getRootDir(), "src");
   }
 
   @OutputDirectory
@@ -49,7 +53,7 @@ public class GenRepoInfoFileExtension implements GenRepoInfoFileConfiguration {
     return sourceDirectory;
   }
 
-  public void setSourceDirectory(File sourceDirectory) {
-    this.sourceDirectory = sourceDirectory;
+  public void setSourceDirectory(Object sourceDirectory) {
+    this.sourceDirectory = project.file(sourceDirectory);
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -44,7 +44,6 @@ import org.gradle.api.plugins.WarPluginConvention;
 import org.gradle.api.tasks.bundling.War;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -91,9 +90,9 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
     File defaultExplodedAppDir = new File(project.getBuildDir(), EXPLODED_APP_DIR_NAME);
     File defaultStagedAppDir = new File(project.getBuildDir(), STAGED_APP_DIR_NAME);
 
-    runExtension = appengine.getExtensions().create(RUN_EXTENSION, Run.class, defaultExplodedAppDir);
-    stageExtension = appengine.getExtensions().create(STAGE_EXTENSION, StageStandard.class, defaultExplodedAppDir, defaultStagedAppDir);
-    deploy.setDeployables(Collections.singletonList(new File(defaultStagedAppDir, "app.yaml")));
+    runExtension = appengine.getExtensions().create(RUN_EXTENSION, Run.class, project, defaultExplodedAppDir);
+    stageExtension = appengine.getExtensions().create(STAGE_EXTENSION, StageStandard.class, project, defaultExplodedAppDir, defaultStagedAppDir);
+    deploy.setDeployables(new File(defaultStagedAppDir, "app.yaml"));
 
     project.afterEvaluate(new Action<Project>() {
       @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
@@ -20,7 +20,10 @@ package com.google.cloud.tools.gradle.appengine.standard.extension;
 import com.google.cloud.tools.appengine.api.devserver.RunConfiguration;
 import com.google.cloud.tools.appengine.api.devserver.StopConfiguration;
 
+import org.gradle.api.Project;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,6 +31,8 @@ import java.util.List;
  * Extension element to define Run configurations for App Engine Standard Environments
  */
 public class Run implements RunConfiguration, StopConfiguration {
+
+  private final Project project;
 
   private List<File> appYamls;
   private String host;
@@ -53,7 +58,8 @@ public class Run implements RunConfiguration, StopConfiguration {
   private String defaultGcsBucketName;
   private String javaHomeDir;
 
-  public Run(File explodedAppDir) {
+  public Run(Project project, File explodedAppDir) {
+    this.project = project;
     appYamls = Collections.singletonList(explodedAppDir);
   }
 
@@ -62,8 +68,8 @@ public class Run implements RunConfiguration, StopConfiguration {
     return appYamls;
   }
 
-  public void setAppYamls(List<File> appYamls) {
-    this.appYamls = appYamls;
+  public void setAppYamls(Object appYamls) {
+    this.appYamls = new ArrayList<>(project.files(appYamls).getFiles());
   }
 
   @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/StageStandard.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/StageStandard.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.gradle.appengine.standard.extension;
 
 import com.google.cloud.tools.appengine.api.deploy.StageStandardConfiguration;
 
+import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
@@ -30,6 +31,8 @@ import java.io.File;
  * Extension element to define Stage configurations for App Engine Standard Environments
  */
 public class StageStandard implements StageStandardConfiguration {
+
+  private final Project project;
 
   private File sourceDirectory;
   private File stagingDirectory;
@@ -44,7 +47,8 @@ public class StageStandard implements StageStandardConfiguration {
   private Boolean disableJarJsps;
   private String runtime;
 
-  public StageStandard(File sourceDirectory, File stagingDirectory) {
+  public StageStandard(Project project, File sourceDirectory, File stagingDirectory) {
+    this.project = project;
     this.sourceDirectory = sourceDirectory;
     this.stagingDirectory = stagingDirectory;
   }
@@ -54,8 +58,8 @@ public class StageStandard implements StageStandardConfiguration {
   public File getSourceDirectory() {
     return sourceDirectory;
   }
-  public void setSourceDirectory(File sourceDirectory) {
-    this.sourceDirectory = sourceDirectory;
+  public void setSourceDirectory(Object sourceDirectory) {
+    this.sourceDirectory = project.file(sourceDirectory);
   }
 
   @Override
@@ -63,8 +67,8 @@ public class StageStandard implements StageStandardConfiguration {
   public File getStagingDirectory() {
     return stagingDirectory;
   }
-  public void setStagingDirectory(File stagingDirectory) {
-    this.stagingDirectory = stagingDirectory;
+  public void setStagingDirectory(Object stagingDirectory) {
+    this.stagingDirectory = project.file(stagingDirectory);
   }
 
   @Override
@@ -74,8 +78,8 @@ public class StageStandard implements StageStandardConfiguration {
     return dockerfile;
   }
 
-  public void setDockerfile(File dockerfile) {
-    this.dockerfile = dockerfile;
+  public void setDockerfile(Object dockerfile) {
+    this.dockerfile = project.file(dockerfile);
   }
 
   @Override

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtensionParserTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtensionParserTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.standard;
+
+import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePlugin;
+import com.google.cloud.tools.gradle.appengine.core.extension.Deploy;
+import com.google.cloud.tools.gradle.appengine.core.extension.Tools;
+import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
+import com.google.cloud.tools.gradle.appengine.standard.extension.StageStandard;
+import com.google.cloud.tools.gradle.appengine.util.ExtensionUtil;
+import com.google.common.base.Charsets;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.WarPlugin;
+import org.gradle.internal.impldep.org.testng.Assert;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class AppEngineStandardExtensionParserTest {
+
+  @Rule
+  public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+  public Project setUpTestProject(String buildFileName) throws IOException {
+    Path buildFile = testProjectDir.getRoot().toPath().resolve("build.gradle");
+    InputStream buildFileContent = getClass().getClassLoader()
+        .getResourceAsStream("projects/AppEnginePluginTest/Extension/" + buildFileName + ".gradle");
+    Files.copy(buildFileContent, buildFile);
+
+    Path webInf = testProjectDir.getRoot().toPath().resolve("src/main/webapp/WEB-INF");
+    Files.createDirectories(webInf);
+    File appengineWebXml = Files.createFile(webInf.resolve("appengine-web.xml")).toFile();
+    Files.write(appengineWebXml.toPath(), "<appengine-web-app/>".getBytes(Charsets.UTF_8));
+
+    Project p = ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+    p.getPluginManager().apply(JavaPlugin.class);
+    p.getPluginManager().apply(WarPlugin.class);
+    p.getPluginManager().apply(AppEngineStandardPlugin.class);
+    ((ProjectInternal) p).evaluate();
+
+    return p;
+  }
+
+  @Test
+  public void testFileAsString() throws IOException {
+    Project p = setUpTestProject("file-as-string");
+
+    ExtensionAware ext = (ExtensionAware) p.getExtensions()
+        .getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
+    Deploy deploy = new ExtensionUtil(ext).get(AppEngineCorePlugin.DEPLOY_EXTENSION);
+    StageStandard stage = new ExtensionUtil(ext).get(AppEngineStandardPlugin.STAGE_EXTENSION);
+    Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
+    Tools tools = new ExtensionUtil(ext).get(AppEngineCorePlugin.TOOLS_EXTENSION);
+
+    Assert.assertEquals(deploy.getDeployables().size(), 1);
+    Assert.assertEquals("test", deploy.getDeployables().get(0).getName());
+    Assert.assertEquals(run.getAppYamls().size(), 1);
+    Assert.assertEquals("test", run.getAppYamls().get(0).getName());
+    Assert.assertEquals("test", stage.getSourceDirectory().getName());
+    Assert.assertEquals("test", stage.getStagingDirectory().getName());
+    Assert.assertEquals("test", stage.getDockerfile().getName());
+    Assert.assertEquals("test", tools.getCloudSdkHome().getName());
+  }
+
+  @Test
+  public void testFilesAsString() throws IOException {
+    Project p = setUpTestProject("files-as-string");
+
+    ExtensionAware ext = (ExtensionAware) p.getExtensions()
+        .getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
+    Deploy deploy = new ExtensionUtil(ext).get(AppEngineCorePlugin.DEPLOY_EXTENSION);
+    Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
+
+    Assert.assertEquals(deploy.getDeployables().size(), 2);
+    Assert.assertEquals("test0", deploy.getDeployables().get(0).getName());
+    Assert.assertEquals("test1", deploy.getDeployables().get(1).getName());
+    Assert.assertEquals(run.getAppYamls().size(), 2);
+    Assert.assertEquals("test0", run.getAppYamls().get(0).getName());
+    Assert.assertEquals("test1", run.getAppYamls().get(1).getName());
+  }
+
+  @Test
+  public void testFileAsFile() throws IOException {
+    Project p = setUpTestProject("file-as-file");
+
+    ExtensionAware ext = (ExtensionAware) p.getExtensions()
+        .getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
+    Deploy deploy = new ExtensionUtil(ext).get(AppEngineCorePlugin.DEPLOY_EXTENSION);
+    StageStandard stage = new ExtensionUtil(ext).get(AppEngineStandardPlugin.STAGE_EXTENSION);
+    Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
+    Tools tools = new ExtensionUtil(ext).get(AppEngineCorePlugin.TOOLS_EXTENSION);
+
+    Assert.assertEquals(deploy.getDeployables().size(), 1);
+    Assert.assertEquals("test", deploy.getDeployables().get(0).getName());
+    Assert.assertEquals(run.getAppYamls().size(), 1);
+    Assert.assertEquals("test", run.getAppYamls().get(0).getName());
+    Assert.assertEquals("test", stage.getSourceDirectory().getName());
+    Assert.assertEquals("test", stage.getStagingDirectory().getName());
+    Assert.assertEquals("test", stage.getDockerfile().getName());
+    Assert.assertEquals("test", tools.getCloudSdkHome().getName());
+  }
+
+  @Test
+  public void testFilesAsFiles() throws IOException {
+    Project p = setUpTestProject("files-as-files");
+
+    ExtensionAware ext = (ExtensionAware) p.getExtensions()
+        .getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
+    Deploy deploy = new ExtensionUtil(ext).get(AppEngineCorePlugin.DEPLOY_EXTENSION);
+    Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
+
+    Assert.assertEquals(deploy.getDeployables().size(), 2);
+    Assert.assertEquals("test0", deploy.getDeployables().get(0).getName());
+    Assert.assertEquals("test1", deploy.getDeployables().get(1).getName());
+    Assert.assertEquals(run.getAppYamls().size(), 2);
+    Assert.assertEquals("test0", run.getAppYamls().get(0).getName());
+    Assert.assertEquals("test1", run.getAppYamls().get(1).getName());
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -53,7 +53,7 @@ import java.util.List;
 public class AppEngineStandardPluginTest {
 
   @Rule
-  public final TemporaryFolder  testProjectDir = new TemporaryFolder();
+  public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
   public void setUpTestProject() throws IOException {
     Path buildFile = testProjectDir.getRoot().toPath().resolve("build.gradle");
@@ -135,25 +135,30 @@ public class AppEngineStandardPluginTest {
   public void testDefaultConfiguration() throws IOException {
     Project p = ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
 
-    File appengineWebXml = new File(testProjectDir.getRoot(), "src/main/webapp/WEB-INF/appengine-web.xml");
+    File appengineWebXml = new File(testProjectDir.getRoot(),
+        "src/main/webapp/WEB-INF/appengine-web.xml");
     appengineWebXml.getParentFile().mkdirs();
     appengineWebXml.createNewFile();
-    Files.write(appengineWebXml.toPath(), "<web-app/>".getBytes());
+    Files.write(appengineWebXml.toPath(), "<appengine-web-app/>".getBytes());
 
     p.getPluginManager().apply(JavaPlugin.class);
     p.getPluginManager().apply(WarPlugin.class);
     p.getPluginManager().apply(AppEngineStandardPlugin.class);
     ((ProjectInternal) p).evaluate();
 
-    ExtensionAware ext = (ExtensionAware) p.getExtensions().getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
+    ExtensionAware ext = (ExtensionAware) p.getExtensions()
+        .getByName(AppEngineCorePlugin.APPENGINE_EXTENSION);
     Deploy deployExt = new ExtensionUtil(ext).get(AppEngineCorePlugin.DEPLOY_EXTENSION);
     StageStandard stageExt = new ExtensionUtil(ext).get(AppEngineStandardPlugin.STAGE_EXTENSION);
     Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
 
     Assert.assertEquals(new File(p.getBuildDir(), "exploded-app"), stageExt.getSourceDirectory());
     Assert.assertEquals(new File(p.getBuildDir(), "staged-app"), stageExt.getStagingDirectory());
-    Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "staged-app/app.yaml")), deployExt.getDeployables());
-    Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "exploded-app")), run.getAppYamls());
+    Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "staged-app/app.yaml")),
+        deployExt.getDeployables());
+    Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "exploded-app")),
+        run.getAppYamls());
     Assert.assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
   }
+
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/file-as-file.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/file-as-file.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,19 @@
  * limitations under the License.
  *
  */
-
-package com.google.cloud.tools.gradle.appengine.core.extension;
-
-import org.gradle.api.Project;
-
-import java.io.File;
-
-/**
- * Extension element to define the location of cloud sdk tooling
- */
-public class Tools {
-
-  private final Project project;
-
-  private File cloudSdkHome;
-
-  public Tools(Project project) {
-    this.project = project;
+appengine {
+  deploy {
+    deployables = file("test")
   }
-
-  public File getCloudSdkHome() {
-    return cloudSdkHome;
+  run {
+    appYamls = new File("test")
   }
-
-  public void setCloudSdkHome(Object cloudSdkHome) {
-    this.cloudSdkHome = project.file(cloudSdkHome);
+  stage {
+    sourceDirectory = file("test")
+    stagingDirectory = new File("test")
+    dockerfile = new File("test")
+  }
+  tools {
+    cloudSdkHome = file("test")
   }
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/file-as-string.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/file-as-string.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,19 @@
  * limitations under the License.
  *
  */
-
-package com.google.cloud.tools.gradle.appengine.core.extension;
-
-import org.gradle.api.Project;
-
-import java.io.File;
-
-/**
- * Extension element to define the location of cloud sdk tooling
- */
-public class Tools {
-
-  private final Project project;
-
-  private File cloudSdkHome;
-
-  public Tools(Project project) {
-    this.project = project;
+appengine {
+  deploy {
+    deployables = "test"
   }
-
-  public File getCloudSdkHome() {
-    return cloudSdkHome;
+  run {
+    appYamls = "test"
   }
-
-  public void setCloudSdkHome(Object cloudSdkHome) {
-    this.cloudSdkHome = project.file(cloudSdkHome);
+  stage {
+    sourceDirectory = "test"
+    stagingDirectory = "test"
+    dockerfile = "test"
+  }
+  tools {
+    cloudSdkHome = "test"
   }
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/files-as-files.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/files-as-files.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,11 @@
  *
  */
 
-package com.google.cloud.tools.gradle.appengine.core.extension;
-
-import org.gradle.api.Project;
-
-import java.io.File;
-
-/**
- * Extension element to define the location of cloud sdk tooling
- */
-public class Tools {
-
-  private final Project project;
-
-  private File cloudSdkHome;
-
-  public Tools(Project project) {
-    this.project = project;
+appengine {
+  deploy {
+    deployables = [new File("test0"), new File("test1")]
   }
-
-  public File getCloudSdkHome() {
-    return cloudSdkHome;
-  }
-
-  public void setCloudSdkHome(Object cloudSdkHome) {
-    this.cloudSdkHome = project.file(cloudSdkHome);
+  run {
+    appYamls = files("test0", "test1")
   }
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/files-as-string.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/files-as-string.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,11 @@
  *
  */
 
-package com.google.cloud.tools.gradle.appengine.core.extension;
-
-import org.gradle.api.Project;
-
-import java.io.File;
-
-/**
- * Extension element to define the location of cloud sdk tooling
- */
-public class Tools {
-
-  private final Project project;
-
-  private File cloudSdkHome;
-
-  public Tools(Project project) {
-    this.project = project;
+appengine {
+  deploy {
+    deployables = ["test0", "test1"]
   }
-
-  public File getCloudSdkHome() {
-    return cloudSdkHome;
-  }
-
-  public void setCloudSdkHome(Object cloudSdkHome) {
-    this.cloudSdkHome = project.file(cloudSdkHome);
+  run {
+    appYamls = ["test0", "test1"]
   }
 }


### PR DESCRIPTION
Before this PR users had to specify a list of Files explicitly

```
appengine {
  deploy {
    deployables = [new File("whatever/app.yaml")]
  }
}
```

but now users can do strings or files or lists of those

```
appengine {
  deploy {
    deployables = "app.yaml"
    deployables = ["app.yaml", "app2.yaml"]
    deployables = new File("app.yaml")
    deployables = [new File("app.yaml"), new File("app2.yaml")]
  }
}
```