### PR TITLE
Update Run config and appengine-plugins-core dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 group = 'com.google.cloud.tools'
-version = '1.2.1-SNAPSHOT'
+version = '1.0.1-SNAPSHOT'
 
 repositories {
   mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 group = 'com.google.cloud.tools'
-version = '1.0.1-SNAPSHOT'
+version = '1.2.1-SNAPSHOT'
 
 repositories {
   mavenCentral()
@@ -30,7 +30,7 @@ repositories {
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile 'com.google.cloud.tools:appengine-plugins-core:0.1.11'
+  compile 'com.google.cloud.tools:appengine-plugins-core:0.2.6'
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compile 'com.google.cloud.tools:appengine-plugins-core:0.2.6'
 
   testCompile 'commons-io:commons-io:2.4'
+  testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-library:1.3'
   testCompile 'org.mockito:mockito-core:2.0.54-beta'
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
@@ -35,8 +35,6 @@ import org.gradle.api.tasks.bundling.War;
 
 import java.io.File;
 
-import javax.annotation.Nullable;
-
 /**
  * Plugin for adding source context into App Engine project
  */
@@ -94,7 +92,7 @@ public class SourceContextPlugin implements Plugin<Project> {
   }
 
   // inject source-context into the META-INF directory of a jar or war
-  private void configureArchiveTask(@Nullable AbstractArchiveTask archiveTask) {
+  private void configureArchiveTask(AbstractArchiveTask archiveTask) {
     if (archiveTask == null) {
       return;
     }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -219,6 +219,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
               @Override
               public void execute(Project project) {
                 stopTask.setRunConfig(runExtension);
+                stopTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
               }
             });
           }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class Run implements RunConfiguration, StopConfiguration {
 
   private final Project project;
+  private int startSuccessTimeout;
 
   private List<File> appYamls;
   private String host;
@@ -57,10 +58,20 @@ public class Run implements RunConfiguration, StopConfiguration {
   private Boolean skipSdkUpdateCheck;
   private String defaultGcsBucketName;
   private String javaHomeDir;
+  private Boolean clearDatastore;
 
   public Run(Project project, File explodedAppDir) {
     this.project = project;
+    startSuccessTimeout = 20;
     appYamls = Collections.singletonList(explodedAppDir);
+  }
+
+  public int getStartSuccessTimeout() {
+    return startSuccessTimeout;
+  }
+
+  public void setStartSuccessTimeout(int startSuccessTimeout) {
+    this.startSuccessTimeout = startSuccessTimeout;
   }
 
   @Override
@@ -270,5 +281,13 @@ public class Run implements RunConfiguration, StopConfiguration {
     this.javaHomeDir = javaHomeDir;
   }
 
+  @Override
+  public Boolean getClearDatastore() {
+    return clearDatastore;
+  }
+
+  public void setClearDatastore(Boolean clearDatastore) {
+    this.clearDatastore = clearDatastore;
+  }
 }
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStartTask.java
@@ -54,7 +54,7 @@ public class DevAppServerStartTask extends DefaultTask {
 
     CloudSdk sdk = cloudSdkBuilderFactory.newBuilder()
         .async(true)
-        .runDevAppServerWait(20)
+        .runDevAppServerWait(runConfig.getStartSuccessTimeout())
         .addStdErrLineListener(listener)
         .addStdOutLineListener(listener)
         .build();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStopTask.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.gradle.appengine.standard.task;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
+import com.google.cloud.tools.gradle.appengine.core.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
 
 import org.gradle.api.DefaultTask;
@@ -30,14 +31,20 @@ import org.gradle.api.tasks.TaskAction;
 public class DevAppServerStopTask extends DefaultTask {
 
   private Run runConfig;
+  private CloudSdkBuilderFactory cloudSdkBuilderFactory;
 
   public void setRunConfig(Run runConfig) {
     this.runConfig = runConfig;
   }
 
+  public void setCloudSdkBuilderFactory(CloudSdkBuilderFactory cloudSdkBuilderFactory) {
+    this.cloudSdkBuilderFactory = cloudSdkBuilderFactory;
+  }
+
   @TaskAction
   public void stopAction() throws AppEngineException {
-    CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(null);
+    CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(
+        cloudSdkBuilderFactory.newBuilder().build());
     server.stop(runConfig);
   }
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/BuildResultFilter.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/BuildResultFilter.java
@@ -25,8 +25,6 @@ import org.gradle.testkit.runner.BuildTask;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 /**
  * Tools to filter gradle test kit runner results
  */
@@ -37,9 +35,8 @@ public class BuildResultFilter {
     return FluentIterable
         .from(buildResult.getTasks())
         .transform(new Function<BuildTask, String>() {
-          @Nullable
           @Override
-          public String apply(@Nullable BuildTask buildTask) {
+          public String apply(BuildTask buildTask) {
             return buildTask.getPath();
           }
         })

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -159,6 +159,7 @@ public class AppEngineStandardPluginTest {
     Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "exploded-app")),
         run.getAppYamls());
     Assert.assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
+    Assert.assertEquals(20, run.getStartSuccessTimeout());
   }
 
 }


### PR DESCRIPTION
Update plugins core to 0.2.6

Allow configurable timeout for appengineStart
Allow clearDatastore flag passthrough

Remove annotations based on transitive findbugs dependency
from appengine-plugins-core

fixes #90 
fixes #7