### PR TITLE
Dev App Server v1 integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,12 @@ repositories {
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile 'com.google.cloud.tools:appengine-plugins-core:0.2.9'
+  compile 'com.google.cloud.tools:appengine-plugins-core:0.3.0'
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-library:1.3'
-  testCompile 'org.mockito:mockito-core:2.0.54-beta'
+  testCompile 'org.mockito:mockito-core:2.7.21'
 }
 
 jar {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/extension/Run.java
@@ -18,30 +18,31 @@
 package com.google.cloud.tools.gradle.appengine.standard.extension;
 
 import com.google.cloud.tools.appengine.api.devserver.RunConfiguration;
-import com.google.cloud.tools.appengine.api.devserver.StopConfiguration;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import org.gradle.api.ProjectConfigurationException;
 
 /**
  * Extension element to define Run configurations for App Engine Standard Environments
  */
-public class Run implements RunConfiguration, StopConfiguration {
+public class Run implements RunConfiguration {
 
   private final Project project;
   private int startSuccessTimeout;
+  private String serverVersion;
 
-  private List<File> appYamls;
+  private List<File> services;
   private String host;
   private Integer port;
   private String adminHost;
   private Integer adminPort;
   private String authDomain;
-  private String storagePath;
+  private File storagePath;
   private String logLevel;
   private Integer maxModuleInstances;
   private Boolean useMtimeFileWatcher;
@@ -57,13 +58,14 @@ public class Run implements RunConfiguration, StopConfiguration {
   private String devAppserverLogLevel;
   private Boolean skipSdkUpdateCheck;
   private String defaultGcsBucketName;
-  private String javaHomeDir;
   private Boolean clearDatastore;
+  private File datastorePath;
 
   public Run(Project project, File explodedAppDir) {
     this.project = project;
     startSuccessTimeout = 20;
-    appYamls = Collections.singletonList(explodedAppDir);
+    services = ImmutableList.of(explodedAppDir);
+    serverVersion = "1";
   }
 
   public int getStartSuccessTimeout() {
@@ -74,18 +76,18 @@ public class Run implements RunConfiguration, StopConfiguration {
     this.startSuccessTimeout = startSuccessTimeout;
   }
 
-  @Override
-  public List<File> getAppYamls() {
-    return appYamls;
+  public String getServerVersion() {
+    return serverVersion;
   }
 
+  public void setServerVersion(String serverVersion) throws ProjectConfigurationException {
+    this.serverVersion = serverVersion;
+  }
+
+  @Deprecated
   public void setAppYamls(Object appYamls) {
-    this.appYamls = new ArrayList<>(project.files(appYamls).getFiles());
-  }
-
-  @Override
-  public List<File> getServices() {
-    return null;
+    project.getLogger().warn("'appYamls' is deprecated, this parameter will set 'services'. Use 'services' in the future.");
+    setServices(appYamls);
   }
 
   @Override
@@ -134,12 +136,12 @@ public class Run implements RunConfiguration, StopConfiguration {
   }
 
   @Override
-  public String getStoragePath() {
+  public File getStoragePath() {
     return storagePath;
   }
 
-  public void setStoragePath(String storagePath) {
-    this.storagePath = storagePath;
+  public void setStoragePath(File storagePath) {
+    this.storagePath = project.file(storagePath);
   }
 
   @Override
@@ -278,21 +280,30 @@ public class Run implements RunConfiguration, StopConfiguration {
   }
 
   @Override
-  public String getJavaHomeDir() {
-    return javaHomeDir;
-  }
-
-  public void setJavaHomeDir(String javaHomeDir) {
-    this.javaHomeDir = javaHomeDir;
-  }
-
-  @Override
   public Boolean getClearDatastore() {
     return clearDatastore;
   }
 
   public void setClearDatastore(Boolean clearDatastore) {
     this.clearDatastore = clearDatastore;
+  }
+
+  @Override
+  public List<File> getServices() {
+    return services;
+  }
+
+  public void setServices(Object services) {
+    this.services = new ArrayList<>(project.files(services).getFiles());
+  }
+
+  @Override
+  public File getDatastorePath() {
+    return datastorePath;
+  }
+
+  public void setDatastorePath(Object datastorePath) {
+    this.datastorePath = project.file(datastorePath);
   }
 }
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerHelper.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.standard.task;
+
+import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
+import com.google.cloud.tools.appengine.api.devserver.DefaultStopConfiguration;
+import com.google.cloud.tools.appengine.api.devserver.StopConfiguration;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
+import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.gradle.api.ProjectConfigurationException;
+
+/**
+ * Helper class for DevAppServer[X]Task to obtain the correct server or configuration based on the
+ * server version
+ */
+public class DevAppServerHelper {
+
+  private static final String V1 = "1";
+  private static final String V2 = "2-alpha";
+  @VisibleForTesting
+  static final List<String> SERVER_VERSIONS = ImmutableList.of(V1, V2);
+
+  private Validator validator = new Validator();
+
+  public AppEngineDevServer getAppServer(CloudSdk sdk, Run run) {
+
+    String serverVersion = run.getServerVersion();
+    validator.validateServerVersion(serverVersion);
+
+    switch (serverVersion) {
+      case V1:
+        return new CloudSdkAppEngineDevServer1(sdk);
+      case V2:
+        return new CloudSdkAppEngineDevServer(sdk);
+      default:
+        throw new AssertionError("Unexpected serverVersion " + run.getServerVersion());
+    }
+  }
+
+  public StopConfiguration getStopConfiguration(Run run) {
+
+    String serverVersion = run.getServerVersion();
+    validator.validateServerVersion(serverVersion);
+
+    DefaultStopConfiguration stop = new DefaultStopConfiguration();
+
+    switch (serverVersion) {
+      case V1:
+          stop.setAdminHost(run.getHost());
+          stop.setAdminPort(run.getPort());
+          return stop;
+      case V2:
+          stop.setAdminHost(run.getAdminHost());
+          stop.setAdminPort(run.getAdminPort());
+          return stop;
+      default:
+        throw new AssertionError("Unexpected serverVersion " + run.getServerVersion());
+    }
+  }
+
+  @VisibleForTesting
+  static class Validator {
+
+    @VisibleForTesting
+    void validateServerVersion(String serverVersion) throws ProjectConfigurationException {
+      if (!SERVER_VERSIONS.contains(serverVersion)) {
+        throw new ProjectConfigurationException(
+            "Invalid serverVersion '" + serverVersion + "' use one of " + SERVER_VERSIONS,
+            null);
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerRunTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerRunTask.java
@@ -20,13 +20,12 @@ package com.google.cloud.tools.gradle.appengine.standard.task;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
 import com.google.cloud.tools.gradle.appengine.core.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
-import com.google.cloud.tools.gradle.appengine.util.io.GradleLoggerOutputListener;
-
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.logging.LogLevel;
+import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -36,6 +35,7 @@ public class DevAppServerRunTask extends DefaultTask {
 
   private Run runConfig;
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
+  private DevAppServerHelper serverHelper = new DevAppServerHelper();
 
   public void setRunConfig(Run runConfig) {
     this.runConfig = runConfig;
@@ -46,10 +46,11 @@ public class DevAppServerRunTask extends DefaultTask {
   }
 
   @TaskAction
-  public void runAction() throws AppEngineException {
+  public void runAction() throws AppEngineException, ProjectConfigurationException {
     CloudSdk sdk = cloudSdkBuilderFactory.newBuilder(getLogger()).build();
-    CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(sdk);
-    server.run(runConfig);
+
+    serverHelper.getAppServer(sdk, runConfig).run(runConfig);
   }
+
 
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStartTask.java
@@ -20,16 +20,13 @@ package com.google.cloud.tools.gradle.appengine.standard.task;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
 import com.google.cloud.tools.gradle.appengine.core.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
-import com.google.cloud.tools.gradle.appengine.util.io.GradleLoggerOutputListener;
-
-import org.gradle.api.DefaultTask;
-import org.gradle.api.logging.LogLevel;
-import org.gradle.api.tasks.TaskAction;
-
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
 
 /**
  * Start the App Engine development server asynchronously
@@ -38,6 +35,7 @@ public class DevAppServerStartTask extends DefaultTask {
 
   private Run runConfig;
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
+  private DevAppServerHelper serverHelper = new DevAppServerHelper();
 
   public void setRunConfig(Run runConfig) {
     this.runConfig = runConfig;
@@ -54,8 +52,8 @@ public class DevAppServerStartTask extends DefaultTask {
         .async(true)
         .runDevAppServerWait(runConfig.getStartSuccessTimeout())
         .build();
-    CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(sdk);
-    server.run(runConfig);
+
+    serverHelper.getAppServer(sdk, runConfig).run(runConfig);
   }
 
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerStopTask.java
@@ -18,6 +18,8 @@
 package com.google.cloud.tools.gradle.appengine.standard.task;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
 import com.google.cloud.tools.gradle.appengine.core.task.CloudSdkBuilderFactory;
 import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
@@ -32,6 +34,7 @@ public class DevAppServerStopTask extends DefaultTask {
 
   private Run runConfig;
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
+  private DevAppServerHelper serverHelper = new DevAppServerHelper();
 
   public void setRunConfig(Run runConfig) {
     this.runConfig = runConfig;
@@ -43,9 +46,10 @@ public class DevAppServerStopTask extends DefaultTask {
 
   @TaskAction
   public void stopAction() throws AppEngineException {
-    CloudSdkAppEngineDevServer server = new CloudSdkAppEngineDevServer(
-        cloudSdkBuilderFactory.newBuilder().build());
-    server.stop(runConfig);
+    CloudSdk sdk = cloudSdkBuilderFactory.newBuilder(getLogger()).build();
+
+    AppEngineDevServer server = serverHelper.getAppServer(sdk, runConfig);
+    server.stop(serverHelper.getStopConfiguration(runConfig));
   }
 
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtensionParserTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtensionParserTest.java
@@ -80,8 +80,8 @@ public class AppEngineStandardExtensionParserTest {
 
     Assert.assertEquals(deploy.getDeployables().size(), 1);
     Assert.assertEquals("test", deploy.getDeployables().get(0).getName());
-    Assert.assertEquals(run.getAppYamls().size(), 1);
-    Assert.assertEquals("test", run.getAppYamls().get(0).getName());
+    Assert.assertEquals(run.getServices().size(), 1);
+    Assert.assertEquals("test", run.getServices().get(0).getName());
     Assert.assertEquals("test", stage.getSourceDirectory().getName());
     Assert.assertEquals("test", stage.getStagingDirectory().getName());
     Assert.assertEquals("test", stage.getDockerfile().getName());
@@ -100,9 +100,9 @@ public class AppEngineStandardExtensionParserTest {
     Assert.assertEquals(deploy.getDeployables().size(), 2);
     Assert.assertEquals("test0", deploy.getDeployables().get(0).getName());
     Assert.assertEquals("test1", deploy.getDeployables().get(1).getName());
-    Assert.assertEquals(run.getAppYamls().size(), 2);
-    Assert.assertEquals("test0", run.getAppYamls().get(0).getName());
-    Assert.assertEquals("test1", run.getAppYamls().get(1).getName());
+    Assert.assertEquals(run.getServices().size(), 2);
+    Assert.assertEquals("test0", run.getServices().get(0).getName());
+    Assert.assertEquals("test1", run.getServices().get(1).getName());
   }
 
   @Test
@@ -118,8 +118,8 @@ public class AppEngineStandardExtensionParserTest {
 
     Assert.assertEquals(deploy.getDeployables().size(), 1);
     Assert.assertEquals("test", deploy.getDeployables().get(0).getName());
-    Assert.assertEquals(run.getAppYamls().size(), 1);
-    Assert.assertEquals("test", run.getAppYamls().get(0).getName());
+    Assert.assertEquals(run.getServices().size(), 1);
+    Assert.assertEquals("test", run.getServices().get(0).getName());
     Assert.assertEquals("test", stage.getSourceDirectory().getName());
     Assert.assertEquals("test", stage.getStagingDirectory().getName());
     Assert.assertEquals("test", stage.getDockerfile().getName());
@@ -138,8 +138,8 @@ public class AppEngineStandardExtensionParserTest {
     Assert.assertEquals(deploy.getDeployables().size(), 2);
     Assert.assertEquals("test0", deploy.getDeployables().get(0).getName());
     Assert.assertEquals("test1", deploy.getDeployables().get(1).getName());
-    Assert.assertEquals(run.getAppYamls().size(), 2);
-    Assert.assertEquals("test0", run.getAppYamls().get(0).getName());
-    Assert.assertEquals("test1", run.getAppYamls().get(1).getName());
+    Assert.assertEquals(run.getServices().size(), 2);
+    Assert.assertEquals("test0", run.getServices().get(0).getName());
+    Assert.assertEquals("test1", run.getServices().get(1).getName());
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -238,7 +238,7 @@ public class AppEngineStandardPluginTest {
     Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "staged-app/app.yaml")),
         deployExt.getDeployables());
     Assert.assertEquals(Collections.singletonList(new File(p.getBuildDir(), "exploded-app")),
-        run.getAppYamls());
+        run.getServices());
     Assert.assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
     Assert.assertEquals(20, run.getStartSuccessTimeout());
   }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/extension/RunExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/extension/RunExtensionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.standard.extension;
+
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public class RunExtensionTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  @Test
+  public void testSetAppYamls() throws IOException {
+    Project p = ProjectBuilder.builder().build();
+    Run run = p.getExtensions().create("run", Run.class, p, tmpDir.getRoot());
+
+    // this is the default
+    Assert.assertEquals(ImmutableList.of(tmpDir.getRoot()), run.getServices());
+
+    File file = new File("/tmp/some/app.yaml");
+    run.setAppYamls(file);
+    // setAppYamls transforms the file list
+    Assert.assertEquals(new ArrayList<>(p.files(file).getFiles()), run.getServices());
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerHelperTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/task/DevAppServerHelperTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.cloud.tools.gradle.appengine.standard.task;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.appengine.api.devserver.StopConfiguration;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
+import com.google.cloud.tools.gradle.appengine.standard.extension.Run;
+import com.google.cloud.tools.gradle.appengine.standard.task.DevAppServerHelper.Validator;
+import org.gradle.api.ProjectConfigurationException;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DevAppServerHelperTest {
+
+  @Mock
+  private CloudSdk sdk;
+
+  @Mock
+  private Run run;
+
+  @Spy
+  private Validator validator;
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @InjectMocks
+  private DevAppServerHelper helper = new DevAppServerHelper();
+
+  @Test
+  public void testGetAppServer_v1() {
+    when(run.getServerVersion()).thenReturn("1");
+    Assert.assertThat(helper.getAppServer(sdk, run), Matchers.instanceOf(CloudSdkAppEngineDevServer1.class));
+    verify(validator, times(1)).validateServerVersion(run.getServerVersion());
+  }
+
+  @Test
+  public void testGetAppServer_v2() {
+    when(run.getServerVersion()).thenReturn("2-alpha");
+    Assert.assertThat(helper.getAppServer(sdk, run), Matchers.instanceOf(CloudSdkAppEngineDevServer.class));
+    verify(validator, times(1)).validateServerVersion(run.getServerVersion());
+  }
+
+  @Test
+  public void testGetAppServer_badValue() {
+    when(run.getServerVersion()).thenReturn("nonsense");
+    exception.expect(ProjectConfigurationException.class);
+    exception.expectMessage("Invalid serverVersion 'nonsense' use one of " + DevAppServerHelper.SERVER_VERSIONS);
+
+    helper.getAppServer(sdk, run);
+  }
+
+  @Test
+  public void getStopConfiguration_v1() {
+    when(run.getServerVersion()).thenReturn("1");
+    when(run.getHost()).thenReturn("v1.com");
+    when(run.getPort()).thenReturn(1234);
+
+    StopConfiguration config = helper.getStopConfiguration(run);
+    Assert.assertEquals("v1.com", config.getAdminHost());
+    Assert.assertEquals(new Integer(1234), config.getAdminPort());
+
+    verify(validator, times(1)).validateServerVersion(run.getServerVersion());
+  }
+
+  @Test
+  public void getStopConfiguration_v2() {
+    when(run.getServerVersion()).thenReturn("2-alpha");
+    when(run.getAdminHost()).thenReturn("v2.com");
+    when(run.getAdminPort()).thenReturn(4321);
+
+    StopConfiguration config = helper.getStopConfiguration(run);
+    Assert.assertEquals("v2.com", config.getAdminHost());
+    Assert.assertEquals(new Integer(4321), config.getAdminPort());
+
+    verify(validator, times(1)).validateServerVersion(run.getServerVersion());
+  }
+
+  @Test
+  public void testGetStopConfiguration_badValue() {
+    when(run.getServerVersion()).thenReturn("nonsense");
+
+    exception.expect(ProjectConfigurationException.class);
+    exception.expectMessage("Invalid serverVersion 'nonsense' use one of " + DevAppServerHelper.SERVER_VERSIONS);
+
+    helper.getStopConfiguration(run);
+  }
+
+  @Test
+  public void testValidator_goodValues() {
+    Validator validatorUnderTest = new Validator();
+
+    validatorUnderTest.validateServerVersion("1");
+    validatorUnderTest.validateServerVersion("2-alpha");
+
+    // should not throw exceptions
+  }
+
+  @Test
+  public void testValidator_badValue() {
+    Validator validatorUnderTest = new Validator();
+
+    exception.expect(ProjectConfigurationException.class);
+    exception.expectMessage("Invalid serverVersion 'nonsense' use one of " + DevAppServerHelper.SERVER_VERSIONS);
+
+    validatorUnderTest.validateServerVersion("nonsense");
+  }
+
+}


### PR DESCRIPTION
- Services replaces AppYamls (setting AppYamls reveals deprecation warning)
- By default, we use dev appserver v1
- users can swap between v1 and v2 by setting
```
appengine {
  run {
    serverVersion = "1" or "2-alpha"
  }
}
```