### PR TITLE
Change build/exploded-app to build/exploded-<project.getName()>

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -42,9 +42,7 @@ import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.WarPluginConvention;
 import org.gradle.api.tasks.bundling.War;
 
-/**
- *  Plugin definition for App Engine standard environments.
- */
+/** Plugin definition for App Engine standard environments. */
 public class AppEngineStandardPlugin implements Plugin<Project> {
 
   private static final String APP_ENGINE_STANDARD_TASK_GROUP = "App Engine standard environment";
@@ -94,11 +92,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
         appengine
             .getExtensions()
             .create(
-                STAGE_EXTENSION,
-                StageStandard.class,
-                project,
-                explodedWarDir,
-                defaultStagedAppDir);
+                STAGE_EXTENSION, StageStandard.class, project, explodedWarDir, defaultStagedAppDir);
     deploy.setDeployables(new File(defaultStagedAppDir, "app.yaml"));
     deploy.setAppEngineDirectory(new File(defaultStagedAppDir, "WEB-INF/appengine-generated"));
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -289,7 +289,8 @@ public class AppEngineStandardPluginTest {
     StageStandard stageExt = new ExtensionUtil(ext).get(AppEngineStandardPlugin.STAGE_EXTENSION);
     Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
 
-    Assert.assertEquals(new File(p.getBuildDir(), "exploded-" + p.getName()), stageExt.getSourceDirectory());
+    Assert.assertEquals(
+        new File(p.getBuildDir(), "exploded-" + p.getName()), stageExt.getSourceDirectory());
     Assert.assertEquals(new File(p.getBuildDir(), "staged-app"), stageExt.getStagingDirectory());
     Assert.assertEquals(
         new File(p.getBuildDir(), "staged-app/WEB-INF/appengine-generated"),
@@ -298,7 +299,8 @@ public class AppEngineStandardPluginTest {
         Collections.singletonList(new File(p.getBuildDir(), "staged-app/app.yaml")),
         deployExt.getDeployables());
     Assert.assertEquals(
-        Collections.singletonList(new File(p.getBuildDir(), "exploded-" + p.getName())), run.getServices());
+        Collections.singletonList(new File(p.getBuildDir(), "exploded-" + p.getName())),
+        run.getServices());
     Assert.assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
     Assert.assertEquals(20, run.getStartSuccessTimeout());
   }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -289,7 +289,7 @@ public class AppEngineStandardPluginTest {
     StageStandard stageExt = new ExtensionUtil(ext).get(AppEngineStandardPlugin.STAGE_EXTENSION);
     Run run = new ExtensionUtil(ext).get(AppEngineStandardPlugin.RUN_EXTENSION);
 
-    Assert.assertEquals(new File(p.getBuildDir(), "exploded-app"), stageExt.getSourceDirectory());
+    Assert.assertEquals(new File(p.getBuildDir(), "exploded-" + p.getName()), stageExt.getSourceDirectory());
     Assert.assertEquals(new File(p.getBuildDir(), "staged-app"), stageExt.getStagingDirectory());
     Assert.assertEquals(
         new File(p.getBuildDir(), "staged-app/WEB-INF/appengine-generated"),
@@ -298,7 +298,7 @@ public class AppEngineStandardPluginTest {
         Collections.singletonList(new File(p.getBuildDir(), "staged-app/app.yaml")),
         deployExt.getDeployables());
     Assert.assertEquals(
-        Collections.singletonList(new File(p.getBuildDir(), "exploded-app")), run.getServices());
+        Collections.singletonList(new File(p.getBuildDir(), "exploded-" + p.getName())), run.getServices());
     Assert.assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
     Assert.assertEquals(20, run.getStartSuccessTimeout());
   }


### PR DESCRIPTION
Because of the way devappsever1 does multi module support, the exploded-app dir name needed to be changed to be unique for each project.

So now instead of exploding into `build/exploded-app`, the output is now directed to `build/exploded-myProject` for gradle project `myProject`

I don't know how this affect users who were using the exploded-war dir by name, but it could have some implications.
With this change, users can access the name we calculate in the build.gradle file by doing.
```
def explodedAppDir = project.tasks.explodeWar.explodedAppDirectory
```