### PR TITLE
Added ability to configure Environment explicitly - #125

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePlugin.java
@@ -63,7 +63,7 @@ public class AppEngineCorePlugin implements Plugin<Project> {
   }
 
   private void createExtensions() {
-    extension = project.getExtensions().create(APPENGINE_EXTENSION, AppEngineExtension.class);
+    extension = getOrCreate();
     deployExtension =
         ((ExtensionAware) extension)
             .getExtensions()
@@ -81,6 +81,16 @@ public class AppEngineCorePlugin implements Plugin<Project> {
             cloudSdkBuilderFactory = new CloudSdkBuilderFactory(toolsExtension.getCloudSdkHome());
           }
         });
+  }
+
+  private AppEngineExtension getOrCreate() {
+    AppEngineExtension appEngineExtension =
+        project.getExtensions().findByType(AppEngineExtension.class);
+    if (appEngineExtension == null) {
+      appEngineExtension =
+          project.getExtensions().create(APPENGINE_EXTENSION, AppEngineExtension.class);
+    }
+    return appEngineExtension;
   }
 
   private void createDeployTask() {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/Environment.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/Environment.java
@@ -1,0 +1,7 @@
+package com.google.cloud.tools.gradle.appengine.core;
+
+/** Environment of the AppEngine that is used to apply Standard of Flexible Appengine plugin. */
+public enum Environment {
+  STANDARD,
+  FLEXIBLE;
+}

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
@@ -43,9 +43,14 @@ public class SourceContextPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     this.project = project;
-
-    createExtension();
-    createSourceContextTask();
+    project.afterEvaluate(
+        new Action<Project>() {
+          @Override
+          public void execute(Project project) {
+            createExtension();
+            createSourceContextTask();
+          }
+        });
   }
 
   private void createExtension() {

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
@@ -1,0 +1,118 @@
+package com.google.cloud.tools.gradle.appengine;
+
+import com.google.cloud.tools.gradle.appengine.flexible.AppEngineFlexiblePlugin;
+import com.google.cloud.tools.gradle.appengine.standard.AppEngineStandardPlugin;
+import com.google.common.base.Charsets;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.api.Project;
+import org.gradle.api.ProjectConfigurationException;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.plugins.UnknownPluginException;
+import org.gradle.api.plugins.WarPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Test AppEnginePlugin environment choosing configuration logic. */
+public class AppEnginePluginTest {
+  @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+  private Project setUpTestProject(final String buildFileName) throws IOException {
+    final Path buildFile = testProjectDir.getRoot().toPath().resolve("build.gradle");
+    final InputStream buildFileContent =
+        getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "projects/AppEnginePluginTest/Extension/" + buildFileName + ".gradle");
+    Files.copy(buildFileContent, buildFile);
+
+    final Project project =
+        ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+    project.getPluginManager().apply(JavaPlugin.class);
+    project.getPluginManager().apply(WarPlugin.class);
+    project.getPluginManager().apply(AppEnginePlugin.class);
+    ((ProjectInternal) project).evaluate();
+
+    return project;
+  }
+
+  @Test(expected = UnknownPluginException.class)
+  public void testExplicitStandardConfiguration() throws IOException {
+    final Project project = setUpTestProject("explicit-standard-environment");
+    final PluginContainer pluginContainer = project.getPlugins();
+    final AppEngineStandardPlugin standardPlugin =
+        pluginContainer.getPlugin(AppEngineStandardPlugin.class);
+    Assert.assertNotNull(standardPlugin);
+    final AppEngineFlexiblePlugin flexiblePlugin =
+        pluginContainer.getPlugin(AppEngineFlexiblePlugin.class);
+    Assert.fail("Flexible plugin should not be found");
+  }
+
+  @Test(expected = UnknownPluginException.class)
+  public void testExplicitFlexibleConfiguration() throws IOException {
+    final Project project = setUpTestProject("explicit-flexible-environment");
+    final PluginContainer pluginContainer = project.getPlugins();
+    final AppEngineFlexiblePlugin flexiblePlugin =
+        pluginContainer.getPlugin(AppEngineFlexiblePlugin.class);
+    Assert.assertNotNull(flexiblePlugin);
+    final AppEngineStandardPlugin standardPlugin =
+        pluginContainer.getPlugin(AppEngineStandardPlugin.class);
+    Assert.fail("Standard plugin should not be found");
+  }
+
+  @Test(expected = ProjectConfigurationException.class)
+  public void testExplicitConfigurationThrowsExceptionForWrongEnvironmentValue()
+      throws IOException {
+    final Project project = setUpTestProject("explicit-unknown-environment");
+    Assert.fail("Configuration should fail due to wrong environment value");
+  }
+
+  @Test(expected = UnknownPluginException.class)
+  public void testImplicitStandardConfiguration() throws IOException {
+    final Path webInf = testProjectDir.getRoot().toPath().resolve("src/main/webapp/WEB-INF");
+    Files.createDirectories(webInf);
+    final File appengineWebXml = Files.createFile(webInf.resolve("appengine-web.xml")).toFile();
+    Files.write(appengineWebXml.toPath(), "<appengine-web-app/>".getBytes(Charsets.UTF_8));
+
+    final Project project =
+        ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+    project.getPluginManager().apply(JavaPlugin.class);
+    project.getPluginManager().apply(WarPlugin.class);
+    project.getPluginManager().apply(AppEnginePlugin.class);
+    ((ProjectInternal) project).evaluate();
+
+    final PluginContainer pluginContainer = project.getPlugins();
+    final AppEngineStandardPlugin standardPlugin =
+        pluginContainer.getPlugin(AppEngineStandardPlugin.class);
+    Assert.assertNotNull(standardPlugin);
+    final AppEngineFlexiblePlugin flexiblePlugin =
+        pluginContainer.getPlugin(AppEngineFlexiblePlugin.class);
+    Assert.fail("Flexible plugin should not be found");
+  }
+
+  @Test(expected = UnknownPluginException.class)
+  public void testImplicitFlexibleConfiguration() throws IOException {
+    final Project project =
+        ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+    project.getPluginManager().apply(JavaPlugin.class);
+    project.getPluginManager().apply(WarPlugin.class);
+    project.getPluginManager().apply(AppEnginePlugin.class);
+    ((ProjectInternal) project).evaluate();
+
+    final PluginContainer pluginContainer = project.getPlugins();
+    final AppEngineFlexiblePlugin flexiblePlugin =
+        pluginContainer.getPlugin(AppEngineFlexiblePlugin.class);
+    Assert.assertNotNull(flexiblePlugin);
+    final AppEngineStandardPlugin standardPlugin =
+        pluginContainer.getPlugin(AppEngineStandardPlugin.class);
+    Assert.fail("Standard plugin should not be found");
+  }
+}

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-flexible-environment.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-flexible-environment.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,6 @@
  * limitations under the License.
  *
  */
-
-package com.google.cloud.tools.gradle.appengine.core;
-
-import org.gradle.api.tasks.Optional;
-
-/** Base Extension class for all our appengine extensions to include themselves into. */
-public class AppEngineExtension {
-  // dynamically fill this in in AppEngineCorePlugin
-  private Environment environment;
-
-  @Optional
-  public Environment getEnvironment() {
-    return environment;
-  }
-
-  public void setEnvironment(final Environment environment) {
-    this.environment = environment;
-  }
+appengine {
+    environment = 'FLEXIBLE'
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-standard-environment.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-standard-environment.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,6 @@
  * limitations under the License.
  *
  */
-
-package com.google.cloud.tools.gradle.appengine.core;
-
-import org.gradle.api.tasks.Optional;
-
-/** Base Extension class for all our appengine extensions to include themselves into. */
-public class AppEngineExtension {
-  // dynamically fill this in in AppEngineCorePlugin
-  private Environment environment;
-
-  @Optional
-  public Environment getEnvironment() {
-    return environment;
-  }
-
-  public void setEnvironment(final Environment environment) {
-    this.environment = environment;
-  }
+appengine {
+    environment = 'STANDARD'
 }

--- a/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-unknown-environment.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/Extension/explicit-unknown-environment.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Google Inc. All Right Reserved.
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,6 @@
  * limitations under the License.
  *
  */
-
-package com.google.cloud.tools.gradle.appengine.core;
-
-import org.gradle.api.tasks.Optional;
-
-/** Base Extension class for all our appengine extensions to include themselves into. */
-public class AppEngineExtension {
-  // dynamically fill this in in AppEngineCorePlugin
-  private Environment environment;
-
-  @Optional
-  public Environment getEnvironment() {
-    return environment;
-  }
-
-  public void setEnvironment(final Environment environment) {
-    this.environment = environment;
-  }
+appengine {
+    environment = 'unknown'
 }


### PR DESCRIPTION
There is now an option to configure environment that would be used by app-gradle plugin explicitly using following syntax:
```
appengine{
  environment = ['standard'|'flexible']
}
```

If no environment was supplied fallback to the previous behaviour would be used.
If environment doesn't match the values above configuration exception would be thrown as environment is an enum.