### PR TITLE
Create a prepareRelease task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 buildscript {
   repositories {
     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,10 @@
 buildscript {
   repositories {
-    jcenter()
     maven {
       url "https://plugins.gradle.org/m2"
     }
   }
   dependencies {
-    classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
     classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6'
   }
 }
@@ -18,7 +16,7 @@ repositories {
   mavenCentral()
 }
 
-apply from: 'scripts/publishing.gradle'
+apply from: 'scripts/releasing.gradle'
 apply from: 'scripts/integTest.gradle'
 apply from: 'scripts/google-java-format.gradle'
 apply from: 'scripts/checkstyle.gradle'

--- a/scripts/checkstyle.gradle
+++ b/scripts/checkstyle.gradle
@@ -1,4 +1,22 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 apply plugin: 'checkstyle'
+
 checkstyle {
   toolVersion = "7.6.1"
   // get the google_checks.xml file from the actual tool we're invoking

--- a/scripts/google-java-format.gradle
+++ b/scripts/google-java-format.gradle
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 apply plugin: 'com.github.sherter.google-java-format'
 
 check.dependsOn verifyGoogleJavaFormat

--- a/scripts/publishing.gradle
+++ b/scripts/publishing.gradle
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 // add this into build.gradle buildscript.classpath if you want to use this script
 // classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
 

--- a/scripts/publishing.gradle
+++ b/scripts/publishing.gradle
@@ -1,3 +1,6 @@
+// add this into build.gradle buildscript.classpath if you want to use this script
+// classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
+
 apply plugin: 'com.bmuschko.nexus'
 
 modifyPom {

--- a/scripts/releasing.gradle
+++ b/scripts/releasing.gradle
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 apply plugin: 'maven-publish'
 
 task sourceJar(type: Jar) {
@@ -51,7 +68,7 @@ task prepareRelease(type: Copy) {
     // https://discuss.gradle.org/t/gradlew-tasks-fails-in-2-4-due-to-not-finding-generatepom-task/10097/9
     tasks.realize() 
     from tasks.generatePomFileForReleasePublication
-    rename("pom-default.xml", "pom.xml")
+    rename("pom-default.xml", "pom-${project.version}.xml")
   }
 
   into "${buildDir}/release"

--- a/scripts/releasing.gradle
+++ b/scripts/releasing.gradle
@@ -15,7 +15,7 @@
  *
  */
 
-apply plugin: 'maven-publish'
+apply plugin: 'maven'
 
 task sourceJar(type: Jar) {
   from sourceSets.main.allJava
@@ -27,34 +27,42 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
   classifier = 'javadoc'
 }
 
-// this is the only way for us to create a pom using the gradle tools
-// usually this same config is used to deploy, but we're deploying
-// using another tool and really just want the pom.
-publishing {
-  publications {
-    release(MavenPublication) {
-      pom.withXml {
-        def root = asNode()
-        root.appendNode('name', 'App Engine Gradle Plugin')
-        root.appendNode('description', 'This Gradle plugin provides tasks to build and deploy Google App Engine applications.')
-        root.appendNode('url', 'https://github.com/GoogleCloudPlatform/app-gradle-plugin')
-        root.appendNode('inceptionYear', '2016')
+task writePom {
+  project.afterEvaluate {
+    def outputFile = file("$buildDir/pom/${project.name}-${project.version}.pom")
+    outputs.file outputFile
 
-        def scm = root.appendNode('scm')
-        scm.appendNode('url', 'https://github.com/GoogleCloudPlatform/app-gradle-plugin')
-        scm.appendNode('connection', 'scm:https://github.com/GoogleCloudPlatform/app-gradle-plugin.git')
-        scm.appendNode('developerConnection', 'scm:git://github.com/GoogleCloudPlatform/app-gradle-plugin.git')
-        
-        def license = root.appendNode('licenses').appendNode('license')
-        license.appendNode('name', 'The Apache Software License, Version 2.0')
-        license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-        license.appendNode('distribution', 'repo')
+    doLast {
+      pom {
+        project {
+          name 'App Engine Gradle Plugin'
+          description 'This Gradle plugin provides tasks to build and deploy Google App Engine applications.'
+          url 'https://github.com/GoogleCloudPlatform/app-gradle-plugin'
+          inceptionYear '2016'
 
-        def developer = root.appendNode('developers').appendNode('developer')
-        developer.appendNode('id', 'loosebazooka')
-        developer.appendNode('name', 'Appu Goundan')
-        developer.appendNode('email', 'appu@google.com')
-      }
+          scm {
+            url 'https://github.com/GoogleCloudPlatform/app-gradle-plugin'
+            connection 'scm:https://github.com/GoogleCloudPlatform/app-gradle-plugin.git'
+            developerConnection 'scm:git://github.com/GoogleCloudPlatform/app-gradle-plugin.git'
+          }
+
+          licenses {
+            license {
+              name 'The Apache Software License, Version 2.0'
+              url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              distribution 'repo'
+            }
+          }
+
+          developers {
+            developer {
+              id 'loosebazooka'
+              name 'Appu Goundan'
+              email 'appu@google.com'
+            }
+          }
+        }
+      }.writeTo(outputFile)
     }
   }
 }
@@ -63,13 +71,7 @@ task prepareRelease(type: Copy) {
   from jar
   from sourceJar
   from javadocJar
-  project.afterEvaluate {
-    // workaround for lazily generated pom publication task 
-    // https://discuss.gradle.org/t/gradlew-tasks-fails-in-2-4-due-to-not-finding-generatepom-task/10097/9
-    tasks.realize() 
-    from tasks.generatePomFileForReleasePublication
-    rename("pom-default.xml", "pom-${project.version}.xml")
-  }
+  from writePom
 
   into "${buildDir}/release"
 

--- a/scripts/releasing.gradle
+++ b/scripts/releasing.gradle
@@ -1,0 +1,61 @@
+apply plugin: 'maven-publish'
+
+task sourceJar(type: Jar) {
+  from sourceSets.main.allJava
+  classifier 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  from javadoc.destinationDir
+  classifier = 'javadoc'
+}
+
+// this is the only way for us to create a pom using the gradle tools
+// usually this same config is used to deploy, but we're deploying
+// using another tool and really just want the pom.
+publishing {
+  publications {
+    release(MavenPublication) {
+      pom.withXml {
+        def root = asNode()
+        root.appendNode('name', 'App Engine Gradle Plugin')
+        root.appendNode('description', 'This Gradle plugin provides tasks to build and deploy Google App Engine applications.')
+        root.appendNode('url', 'https://github.com/GoogleCloudPlatform/app-gradle-plugin')
+        root.appendNode('inceptionYear', '2016')
+
+        def scm = root.appendNode('scm')
+        scm.appendNode('url', 'https://github.com/GoogleCloudPlatform/app-gradle-plugin')
+        scm.appendNode('connection', 'scm:https://github.com/GoogleCloudPlatform/app-gradle-plugin.git')
+        scm.appendNode('developerConnection', 'scm:git://github.com/GoogleCloudPlatform/app-gradle-plugin.git')
+        
+        def license = root.appendNode('licenses').appendNode('license')
+        license.appendNode('name', 'The Apache Software License, Version 2.0')
+        license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
+        license.appendNode('distribution', 'repo')
+
+        def developer = root.appendNode('developers').appendNode('developer')
+        developer.appendNode('id', 'loosebazooka')
+        developer.appendNode('name', 'Appu Goundan')
+        developer.appendNode('email', 'appu@google.com')
+      }
+    }
+  }
+}
+
+task prepareRelease(type: Copy) {
+  from jar
+  from sourceJar
+  from javadocJar
+  project.afterEvaluate {
+    // workaround for lazily generated pom publication task 
+    // https://discuss.gradle.org/t/gradlew-tasks-fails-in-2-4-due-to-not-finding-generatepom-task/10097/9
+    tasks.realize() 
+    from tasks.generatePomFileForReleasePublication
+    rename("pom-default.xml", "pom.xml")
+  }
+
+  into "${buildDir}/release"
+
+  dependsOn build
+  dependsOn cleanPrepareRelease
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,18 @@
+/*
+ * Copyright (c) 2017 Google Inc. All Right Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 rootProject.name = "appengine-gradle-plugin"


### PR DESCRIPTION
- Publish release artifacts to "${buildDir}/release" with "prepareRelease" task
- Remove gradle nexus publish option "upload"
  - code still remains in scripts/publishing.gradle