### PR TITLE
Update version number of AppEngine Gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.0'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.1'
   }
 }
 ```


### PR DESCRIPTION
Hi, 

I noticed [maven central](https://mvnrepository.com/artifact/com.google.cloud.tools/appengine-gradle-plugin/1.3.1) has the version at 1.3.1 while the README is defined as 1.3.0. 


