### PR TITLE
Log Dev App Server output to file

### DIFF
--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -95,7 +95,8 @@ public class AppEngineStandardPluginIntegrationTest {
       String devAppServerOutput =
           FileUtils.readFileToString(new File(expectedLogFileDir, devAppserverLogFiles[0]));
       System.out.println(devAppServerOutput);
-      Assert.assertTrue(devAppServerOutput.contains("Dev App Server is now running")
+      Assert.assertTrue(
+          devAppServerOutput.contains("Dev App Server is now running")
               || devAppServerOutput.contains("INFO:oejs.Server:main: Started"));
 
       AssertConnection.assertResponse(

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -47,8 +46,8 @@ public class AppEngineStandardPluginIntegrationTest {
   @Parameterized.Parameters
   public static Object[] data() {
     return new Object[] {
-        "src/integTest/resources/projects/standard-project",
-        "src/integTest/resources/projects/standard-project-java8"
+      "src/integTest/resources/projects/standard-project",
+      "src/integTest/resources/projects/standard-project-java8"
     };
   }
 
@@ -88,12 +87,13 @@ public class AppEngineStandardPluginIntegrationTest {
 
       File expectedLogFileDir = new File(testProjectDir.getRoot(), "/build/tmp/appengineStart");
       DirectoryScanner ds = new DirectoryScanner();
-      ds.setIncludes(new String[]{"dev_appserver*.out"});
+      ds.setIncludes(new String[] {"dev_appserver*.out"});
       ds.setBasedir(expectedLogFileDir);
       ds.scan();
       String[] devAppserverLogFiles = ds.getIncludedFiles();
       Assert.assertEquals(1, devAppserverLogFiles.length);
-      String devAppServerOutput = FileUtils.readFileToString(new File(expectedLogFileDir, devAppserverLogFiles[0]));
+      String devAppServerOutput =
+          FileUtils.readFileToString(new File(expectedLogFileDir, devAppserverLogFiles[0]));
       System.out.println(devAppServerOutput);
       Assert.assertTrue(
           devAppServerOutput.contains("Dev App Server is now running")

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.internal.process.ProcessRunnerException;
 import com.google.cloud.tools.appengine.cloudsdk.process.NonZeroExceptionExitListener;
+import com.google.cloud.tools.gradle.appengine.standard.AppEngineStandardPlugin;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -85,7 +86,10 @@ public class AppEngineStandardPluginIntegrationTest {
           .withArguments("appengineStart")
           .build();
 
-      File expectedLogFileDir = new File(testProjectDir.getRoot(), "/build/tmp/appengineStart");
+      File expectedLogFileDir =
+          new File(
+              testProjectDir.getRoot(),
+              "/build/" + AppEngineStandardPlugin.DEV_APP_SERVER_OUTPUT_DIR_NAME);
       DirectoryScanner ds = new DirectoryScanner();
       ds.setIncludes(new String[] {"dev_appserver*.out"});
       ds.setBasedir(expectedLogFileDir);
@@ -102,6 +106,8 @@ public class AppEngineStandardPluginIntegrationTest {
       AssertConnection.assertResponse(
           "http://localhost:8080", 200, "Hello from the App Engine Standard project.");
 
+    } finally {
+      // we want to keep the state clean, so stop the server whether the test fails or not
       GradleRunner.create()
           .withProjectDir(testProjectDir.getRoot())
           .withPluginClasspath()
@@ -112,13 +118,6 @@ public class AppEngineStandardPluginIntegrationTest {
       Thread.sleep(8000);
 
       AssertConnection.assertUnreachable("http://localhost:8080");
-    } finally {
-      // just in case the test fails, make sure we stop the dev appserver
-      GradleRunner.create()
-          .withProjectDir(testProjectDir.getRoot())
-          .withPluginClasspath()
-          .withArguments("appengineStop")
-          .build();
     }
   }
 

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -95,13 +95,12 @@ public class AppEngineStandardPluginIntegrationTest {
       String devAppServerOutput =
           FileUtils.readFileToString(new File(expectedLogFileDir, devAppserverLogFiles[0]));
       System.out.println(devAppServerOutput);
-      Assert.assertTrue(
-          devAppServerOutput.contains("Dev App Server is now running")
+      Assert.assertTrue(devAppServerOutput.contains("Dev App Server is now running")
               || devAppServerOutput.contains("INFO:oejs.Server:main: Started"));
 
       AssertConnection.assertResponse(
           "http://localhost:8080", 200, "Hello from the App Engine Standard project.");
-    } finally {
+
       GradleRunner.create()
           .withProjectDir(testProjectDir.getRoot())
           .withPluginClasspath()
@@ -112,6 +111,13 @@ public class AppEngineStandardPluginIntegrationTest {
       Thread.sleep(8000);
 
       AssertConnection.assertUnreachable("http://localhost:8080");
+    } finally {
+      // just in case the test fails, make sure we stop the dev appserver
+      GradleRunner.create()
+          .withProjectDir(testProjectDir.getRoot())
+          .withPluginClasspath()
+          .withArguments("appengineStop")
+          .build();
     }
   }
 

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
@@ -53,7 +53,7 @@ public class AssertConnection {
             (HttpURLConnection) new URL("http://localhost:8080").openConnection();
         urlConnection.getResponseCode();
       } catch (ConnectException ce) {
-        return;  // ConnectException is what we want
+        return; // ConnectException is what we want
       }
       Thread.sleep(500);
     }

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
@@ -43,16 +43,20 @@ public class AssertConnection {
   }
 
   /** Connect and assert that the target is unreachable. */
-  public static void assertUnreachable(String url) throws IOException {
-    try {
-      HttpURLConnection urlConnection =
-          (HttpURLConnection) new URL("http://localhost:8080").openConnection();
-      urlConnection.getResponseCode();
-      Assert.fail("ConnectException expected");
-    } catch (IOException e) {
-      if (!(e instanceof ConnectException)) {
-        throw e;
+  public static void assertUnreachable(String url, long timeoutInMillis)
+      throws IOException, InterruptedException {
+
+    long startTime = System.currentTimeMillis();
+    while (System.currentTimeMillis() - startTime < timeoutInMillis) {
+      try {
+        HttpURLConnection urlConnection =
+            (HttpURLConnection) new URL("http://localhost:8080").openConnection();
+        urlConnection.getResponseCode();
+      } catch (ConnectException ce) {
+        return;  // ConnectException is what we want
       }
+      Thread.sleep(500);
     }
+    Assert.fail("ConnectException expected");
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -41,7 +41,8 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
   public static final String START_TASK_NAME = "appengineStart";
   public static final String STOP_TASK_NAME = "appengineStop";
 
-  private static final String STAGED_APP_DIR_NAME = "staged-app";
+  public static final String STAGED_APP_DIR_NAME = "staged-app";
+  public static final String DEV_APP_SERVER_OUTPUT_DIR_NAME = "dev-appserver-out";
 
   public static final String STAGE_EXTENSION = "stage";
   public static final String RUN_EXTENSION = "run";
@@ -215,6 +216,8 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
                       public void execute(Project project) {
                         startTask.setRunConfig(runExtension);
                         startTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
+                        startTask.setDevAppServerLoggingDir(
+                            new File(project.getBuildDir(), DEV_APP_SERVER_OUTPUT_DIR_NAME));
                       }
                     });
               }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -59,7 +59,7 @@ public class DevAppServerStartTask extends DefaultTask {
     // Add a listener to write to a file for non-blocking starts, this really only works
     // when the gradle daemon is running (which is default for newer versions of gradle)
     File logFile =
-        new File(devAppServerLoggingDir, "dev_appserver" + System.currentTimeMillis() + ".out");
+        new File(devAppServerLoggingDir, "dev_appserver.out");
     FileOutputLineListener logFileWriter = new FileOutputLineListener(logFile);
 
     CloudSdk sdk =

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -58,8 +58,7 @@ public class DevAppServerStartTask extends DefaultTask {
 
     // Add a listener to write to a file for non-blocking starts, this really only works
     // when the gradle daemon is running (which is default for newer versions of gradle)
-    File logFile =
-        new File(devAppServerLoggingDir, "dev_appserver.out");
+    File logFile = new File(devAppServerLoggingDir, "dev_appserver.out");
     FileOutputLineListener logFileWriter = new FileOutputLineListener(logFile);
 
     CloudSdk sdk =

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -24,6 +24,8 @@ import com.google.cloud.tools.gradle.appengine.util.io.FileOutputLineListener;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 /** Start the App Engine development server asynchronously. */
@@ -32,6 +34,7 @@ public class DevAppServerStartTask extends DefaultTask {
   private RunExtension runConfig;
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
   private DevAppServerHelper serverHelper = new DevAppServerHelper();
+  private File devAppServerLoggingDir;
 
   public void setRunConfig(RunExtension runConfig) {
     this.runConfig = runConfig;
@@ -41,13 +44,23 @@ public class DevAppServerStartTask extends DefaultTask {
     this.cloudSdkBuilderFactory = cloudSdkBuilderFactory;
   }
 
+  public void setDevAppServerLoggingDir(File devAppServerLoggingDir) {
+    this.devAppServerLoggingDir = devAppServerLoggingDir;
+  }
+
+  @OutputDirectory
+  public File getDevAppServerLoggingDir() {
+    return devAppServerLoggingDir;
+  }
+
   /** Task entrypoint : start the dev appserver (non-blocking). */
   @TaskAction
   public void startAction() throws AppEngineException, IOException {
 
     // Add a listener to write to a file for non-blocking starts, this really only works
     // when the gradle daemon is running (which is default for newer versions of gradle)
-    File logFile = File.createTempFile("dev_appserver", ".out", getTemporaryDir());
+    File logFile =
+        new File(devAppServerLoggingDir, "dev_appserver" + System.currentTimeMillis() + ".out");
     FileOutputLineListener logFileWriter = new FileOutputLineListener(logFile);
 
     CloudSdk sdk =
@@ -63,4 +76,5 @@ public class DevAppServerStartTask extends DefaultTask {
 
     getLogger().lifecycle("Dev App Server output written to : " + logFile.getAbsolutePath());
   }
+
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -24,7 +24,6 @@ import com.google.cloud.tools.gradle.appengine.util.io.FileOutputLineListener;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
@@ -76,5 +75,4 @@ public class DevAppServerStartTask extends DefaultTask {
 
     getLogger().lifecycle("Dev App Server output written to : " + logFile.getAbsolutePath());
   }
-
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/io/FileOutputLineListener.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/io/FileOutputLineListener.java
@@ -22,8 +22,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 
+/** A listener that redirects process output to a file. */
 public class FileOutputLineListener implements ProcessOutputLineListener {
-  final PrintStream logFilePrinter;
+  private final PrintStream logFilePrinter;
 
   public FileOutputLineListener(File logFile) throws IOException {
     logFilePrinter = new PrintStream(logFile);


### PR DESCRIPTION
This is useful in particular for Android Studio users who want to use the new plugin. Currently once they start the app server using "appengineStart", they don't see any output past "Dev App Server is now running". After this change, they can `tail` the output file and monitor dev-appserver output.