### PR TITLE
Use sync instead of copy on the explodeWar task

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
@@ -18,49 +18,15 @@
 package com.google.cloud.tools.gradle.appengine.standard;
 
 import java.io.File;
-import org.gradle.api.Action;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.file.CopySpec;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.Sync;
 
 /** Expand a war. */
-public class ExplodeWarTask extends DefaultTask {
-
-  private File warFile;
-  private File explodedAppDirectory;
-
-  @InputFile
-  public File getWarFile() {
-    return warFile;
-  }
-
-  @OutputDirectory
-  public File getExplodedAppDirectory() {
-    return explodedAppDirectory;
-  }
-
+public class ExplodeWarTask extends Sync {
   public void setWarFile(File warFile) {
-    this.warFile = warFile;
+    from(getProject().zipTree(warFile));
   }
 
   public void setExplodedAppDirectory(File explodedAppDirectory) {
-    this.explodedAppDirectory = explodedAppDirectory;
-  }
-
-  /** Task entrypoint : expand the war. */
-  @TaskAction
-  public void explodeApp() {
-    getProject().delete(explodedAppDirectory);
-    getProject()
-        .copy(
-            new Action<CopySpec>() {
-              @Override
-              public void execute(CopySpec copySpec) {
-                copySpec.from(getProject().zipTree(warFile));
-                copySpec.into(explodedAppDirectory);
-              }
-            });
+    into(explodedAppDirectory);
   }
 }


### PR DESCRIPTION
This pull request improves processing time and battery consumption for the `explodeWar` task by using [sync task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Sync.html). Current implementation always copies all files (big JARs!) but this copies only modified files.