### PR TITLE
Upgrade appengine-plugins-core to 0.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ group = 'com.google.cloud.tools'
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile 'com.google.cloud.tools:appengine-plugins-core:0.3.2'
+  compile 'com.google.cloud.tools:appengine-plugins-core:0.3.9'
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
We need to pick up fixes in recent releases.