### PR TITLE
Upgrades appengine-plugins-core version to 0.3.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 * Check minimum gradle version ([#169](https://github.com/GoogleCloudPlatform/app-gradle-plugin/issues/169))
+* New `<additionalArguments>` parameter to pass additional arguments to Dev App Server ([#179](../../pulls/179)),
+relevant pull request in App Engine Plugins Core:
+[appengine-plugins-core/433](https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/433)
 
 ### Fixed
 * Gradle 3.4.1 is required.
+* Upgrade App Engine Plugins Core dependency to 0.3.9 ([#179](../../pulls/179))
 
 ## 1.3.3
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -109,6 +109,7 @@ Valid for versions "1" and "2-alpha"
 | `startSuccessTimeout` | Amount of time in seconds to wait for the Dev App Server to start in the background. |
 | `serverVersion`       | Server versions to use, options are "1" or "2-alpha" |
 | `services`            | List of services to run |
+| `additionalArguments` | Additional arguments to pass to the Dev App Server process |
 
 Only valid for version "2-alpha"
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ group = 'com.google.cloud.tools'
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile 'com.google.cloud.tools:appengine-plugins-core:0.3.2'
+  compile 'com.google.cloud.tools:appengine-plugins-core:0.3.9'
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'junit:junit:4.12'

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 
@@ -57,6 +59,7 @@ public class RunExtension implements RunConfiguration {
   private Boolean clearDatastore;
   private File datastorePath;
   private Map<String, String> environment;
+  private List<String> additionalArguments;
 
   /**
    * Constructor.
@@ -317,5 +320,14 @@ public class RunExtension implements RunConfiguration {
 
   public void setEnvironment(Map<String, String> environment) {
     this.environment = environment;
+  }
+
+  @Override
+  public List<String> getAdditionalArguments() {
+    return additionalArguments;
+  }
+
+  public void setAdditionalArguments(List<String> additionalArguments) {
+    this.additionalArguments = additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -18,12 +18,11 @@
 package com.google.cloud.tools.gradle.appengine.standard;
 
 import com.google.cloud.tools.appengine.api.devserver.RunConfiguration;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 
@@ -328,6 +327,7 @@ public class RunExtension implements RunConfiguration {
   }
 
   public void setAdditionalArguments(List<String> additionalArguments) {
-    this.additionalArguments = additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
+    this.additionalArguments =
+        additionalArguments != null ? ImmutableList.copyOf(additionalArguments) : null;
   }
 }


### PR DESCRIPTION
First step of #177 . This adds support for additional arguments to pass to dev app server that was added in https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/432.