### PR TITLE
Construct ManagedCloudSdk at configuration time

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -87,7 +87,7 @@ public class AppEngineCorePluginConfiguration {
                         ? managedCloudSdk.getSdkHome().toFile()
                         : toolsExtension.getCloudSdkHome());
           } catch (UnsupportedOsException | BadCloudSdkVersionException ex) {
-            throw new GradleException(ex.getMessage());
+            throw new GradleException("Configuring... ", ex);
           }
         });
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -79,16 +79,19 @@ public class AppEngineCorePluginConfiguration {
     project.afterEvaluate(
         project -> {
           try {
-            managedCloudSdk =
-                new ManagedCloudSdkFactory(toolsExtension.getCloudSdkVersion()).newManagedSdk();
-            cloudSdkBuilderFactory =
-                new CloudSdkBuilderFactory(
-                    toolsExtension.getCloudSdkHome() == null
-                        ? managedCloudSdk.getSdkHome().toFile()
-                        : toolsExtension.getCloudSdkHome());
+            if (toolsExtension.getCloudSdkHome() == null) {
+              managedCloudSdk =
+                  new ManagedCloudSdkFactory(toolsExtension.getCloudSdkVersion()).newManagedSdk();
+            }
           } catch (UnsupportedOsException | BadCloudSdkVersionException ex) {
             throw new GradleException("Configuring... ", ex);
           }
+
+          cloudSdkBuilderFactory =
+              new CloudSdkBuilderFactory(
+                  managedCloudSdk != null
+                      ? managedCloudSdk.getSdkHome().toFile()
+                      : toolsExtension.getCloudSdkHome());
         });
   }
 
@@ -130,7 +133,6 @@ public class AppEngineCorePluginConfiguration {
                         && toolsExtension.getCloudSdkVersion() != null) {
                       checkCloudSdkTask.setVersion(toolsExtension.getCloudSdkVersion());
                       checkCloudSdkTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
-
                       p.getTasks()
                           .matching(task -> task.getName().startsWith("appengine"))
                           .forEach(task -> task.dependsOn(checkCloudSdkTask));

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -56,7 +56,7 @@ public class AppEngineCorePluginConfiguration {
       Project project,
       AppEngineCoreExtensionProperties appEngineCoreExtensionProperties,
       String taskGroup) {
-    checkGradleVersion(project);
+    checkGradleVersion();
 
     this.project = project;
     this.taskGroup = taskGroup;
@@ -263,7 +263,7 @@ public class AppEngineCorePluginConfiguration {
             });
   }
 
-  private void checkGradleVersion(Project project) {
+  private void checkGradleVersion() {
     if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
       throw new GradleException(
           "Detected "

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -104,9 +104,8 @@ public class AppEngineCorePluginConfiguration {
 
               project.afterEvaluate(
                   p -> {
-                    downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
-
                     if (toolsExtension.getCloudSdkHome() == null) {
+                      downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
                       p.getTasks()
                           .matching(task -> task.getName().startsWith("appengine"))
                           .forEach(task -> task.dependsOn(downloadCloudSdkTask));
@@ -127,11 +126,11 @@ public class AppEngineCorePluginConfiguration {
 
               project.afterEvaluate(
                   p -> {
-                    checkCloudSdkTask.setToolsExtension(toolsExtension);
-                    checkCloudSdkTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
-
                     if (toolsExtension.getCloudSdkHome() != null
                         && toolsExtension.getCloudSdkVersion() != null) {
+                      checkCloudSdkTask.setVersion(toolsExtension.getCloudSdkVersion());
+                      checkCloudSdkTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
+
                       p.getTasks()
                           .matching(task -> task.getName().startsWith("appengine"))
                           .forEach(task -> task.dependsOn(checkCloudSdkTask));

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkVersionFileException;
 import com.google.common.base.Strings;
-import java.io.File;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
@@ -32,10 +31,10 @@ import org.gradle.api.tasks.TaskExecutionException;
 public class CheckCloudSdkTask extends DefaultTask {
 
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
-  private ToolsExtension toolsExtension;
+  private String version;
 
-  public void setToolsExtension(ToolsExtension toolsExtension) {
-    this.toolsExtension = toolsExtension;
+  public void setVersion(String version) {
+    this.version = version;
   }
 
   public void setCloudSdkBuilderFactory(CloudSdkBuilderFactory cloudSdkBuilderFactory) {
@@ -45,14 +44,9 @@ public class CheckCloudSdkTask extends DefaultTask {
   /** Task entrypoint : Verify Cloud SDK installation. */
   @TaskAction
   public void checkCloudSdkAction() {
-    File home = toolsExtension.getCloudSdkHome();
-    if (home == null) {
-      throw new GradleException("SDK home directory must be specified for validation.");
-    }
-
-    String version = toolsExtension.getCloudSdkVersion();
-    if (Strings.isNullOrEmpty(version)) {
-      throw new GradleException("SDK version must be specified for validation.");
+    if (Strings.isNullOrEmpty(version) || cloudSdkBuilderFactory == null) {
+      throw new GradleException(
+          "Cloud SDK home path and version must be configured in order to run this task.");
     }
 
     CloudSdk cloudSdk = cloudSdkBuilderFactory.newBuilder().build();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkVersionFileException;
+import com.google.common.base.Strings;
 import java.io.File;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -50,6 +51,10 @@ public class CheckCloudSdkTask extends DefaultTask {
     }
 
     String version = toolsExtension.getCloudSdkVersion();
+    if (Strings.isNullOrEmpty(version)) {
+      throw new GradleException("SDK version must be specified for validation.");
+    }
+
     CloudSdk cloudSdk = cloudSdkBuilderFactory.newBuilder().build();
     if (!version.equals(cloudSdk.getVersion().toString())) {
       throw new GradleException(

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -44,6 +44,8 @@ public class CheckCloudSdkTask extends DefaultTask {
   /** Task entrypoint : Verify Cloud SDK installation. */
   @TaskAction
   public void checkCloudSdkAction() {
+    // These properties are only set by AppEngineCorePluginConfiguration if the correct config
+    // params are set in the tools extension.
     if (Strings.isNullOrEmpty(version) || cloudSdkBuilderFactory == null) {
       throw new GradleException(
           "Cloud SDK home path and version must be configured in order to run this task.");

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkBuilderFactory.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkBuilderFactory.java
@@ -34,10 +34,6 @@ public class CloudSdkBuilderFactory {
     this.cloudSdkHome = cloudSdkHome;
   }
 
-  public void setCloudSdkHome(File cloudSdkHome) {
-    this.cloudSdkHome = cloudSdkHome;
-  }
-
   /** Create a empty builder with auto-configured metrics and failure on non-zero exit. */
   public CloudSdk.Builder newBuilder() {
     return new CloudSdk.Builder()

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -48,6 +48,7 @@ public class DownloadCloudSdkTask extends DefaultTask {
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
           InterruptedException, CommandExecutionException, SdkInstallerException,
           CommandExitException, IOException {
+    // managedCloudSdk is set by AppEngineCorePluginConfiguration if the cloud SDK home is empty
     if (managedCloudSdk == null) {
       throw new GradleException("Cloud SDK home path must not be configured to run this task.");
     }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -17,13 +17,11 @@
 
 package com.google.cloud.tools.gradle.appengine.core;
 
-import com.google.cloud.tools.managedcloudsdk.BadCloudSdkVersionException;
 import com.google.cloud.tools.managedcloudsdk.ConsoleListener;
 import com.google.cloud.tools.managedcloudsdk.ManagedCloudSdk;
 import com.google.cloud.tools.managedcloudsdk.ManagedSdkVerificationException;
 import com.google.cloud.tools.managedcloudsdk.ManagedSdkVersionMismatchException;
 import com.google.cloud.tools.managedcloudsdk.ProgressListener;
-import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.components.SdkComponent;
@@ -37,27 +35,20 @@ import org.gradle.api.tasks.TaskAction;
 
 public class DownloadCloudSdkTask extends DefaultTask {
 
-  private CloudSdkBuilderFactory cloudSdkBuilderFactory;
-  private ManagedCloudSdkFactory managedCloudSdkFactory;
+  private ManagedCloudSdk managedCloudSdk;
 
-  public void setCloudSdkBuilderFactory(CloudSdkBuilderFactory cloudSdkBuilderFactory) {
-    this.cloudSdkBuilderFactory = cloudSdkBuilderFactory;
-  }
-
-  public void setManagedCloudSdkFactory(ManagedCloudSdkFactory managedCloudSdkFactory) {
-    this.managedCloudSdkFactory = managedCloudSdkFactory;
+  public void setManagedCloudSdk(ManagedCloudSdk managedCloudSdk) {
+    this.managedCloudSdk = managedCloudSdk;
   }
 
   /** Task entrypoint : Download/update Cloud SDK. */
   @TaskAction
   public void downloadCloudSdkAction()
-      throws UnsupportedOsException, BadCloudSdkVersionException, ManagedSdkVerificationException,
-          ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-          SdkInstallerException, CommandExitException, IOException {
+      throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
+          InterruptedException, CommandExecutionException, SdkInstallerException,
+          CommandExitException, IOException {
     ProgressListener progressListener = new NopProgressListener();
     ConsoleListener consoleListener = new DownloadCloudSdkTaskConsoleListener(getProject());
-
-    ManagedCloudSdk managedCloudSdk = managedCloudSdkFactory.newManagedSdk();
 
     // Install sdk if not installed
     if (!managedCloudSdk.isInstalled()) {
@@ -77,7 +68,5 @@ public class DownloadCloudSdkTask extends DefaultTask {
       SdkUpdater updater = managedCloudSdk.newUpdater();
       updater.update(progressListener, consoleListener);
     }
-
-    cloudSdkBuilderFactory.setCloudSdkHome(managedCloudSdk.getSdkHome().toFile());
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -52,7 +52,7 @@ public class DownloadCloudSdkTask extends DefaultTask {
       throw new GradleException("Cloud SDK home path must not be configured to run this task.");
     }
 
-    ProgressListener progressListener = new NopProgressListener();
+    ProgressListener progressListener = new NoOpProgressListener();
     ConsoleListener consoleListener = new DownloadCloudSdkTaskConsoleListener(getProject());
 
     // Install sdk if not installed

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -31,6 +31,7 @@ import com.google.cloud.tools.managedcloudsdk.install.SdkInstallerException;
 import com.google.cloud.tools.managedcloudsdk.update.SdkUpdater;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 
 public class DownloadCloudSdkTask extends DefaultTask {
@@ -47,6 +48,10 @@ public class DownloadCloudSdkTask extends DefaultTask {
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
           InterruptedException, CommandExecutionException, SdkInstallerException,
           CommandExitException, IOException {
+    if (managedCloudSdk == null) {
+      throw new GradleException("Cloud SDK home path must not be configured to run this task.");
+    }
+
     ProgressListener progressListener = new NopProgressListener();
     ConsoleListener consoleListener = new DownloadCloudSdkTaskConsoleListener(getProject());
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/NoOpProgressListener.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/NoOpProgressListener.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.gradle.appengine.core;
 
 import com.google.cloud.tools.managedcloudsdk.ProgressListener;
 
-class NopProgressListener implements ProgressListener {
+class NoOpProgressListener implements ProgressListener {
   @Override
   public void start(String message, long totalWork) {}
 
@@ -34,6 +34,6 @@ class NopProgressListener implements ProgressListener {
 
   @Override
   public ProgressListener newChild(long allocation) {
-    return new NopProgressListener();
+    return new NoOpProgressListener();
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
@@ -78,6 +78,19 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
+  public void testCheckCloudSdkAction_nullVersion() throws IOException {
+    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
+    when(toolsExtension.getCloudSdkVersion()).thenReturn(null);
+
+    try {
+      checkCloudSdkTask.checkCloudSdkAction();
+      Assert.fail();
+    } catch (GradleException ex) {
+      Assert.assertEquals("SDK version must be specified for validation.", ex.getMessage());
+    }
+  }
+
+  @Test
   public void testCheckCloudSdkAction_versionMismatch() throws IOException {
     when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
@@ -43,7 +43,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CheckCloudSdkTaskTest {
 
-  @Mock private ToolsExtension toolsExtension;
   @Mock private CloudSdkBuilderFactory cloudSdkBuilderFactory;
 
   @Mock private CloudSdk.Builder builder;
@@ -59,44 +58,28 @@ public class CheckCloudSdkTaskTest {
     Project tempProject = ProjectBuilder.builder().build();
     checkCloudSdkTask = tempProject.getTasks().create("tempCheckCloudSdk", CheckCloudSdkTask.class);
     checkCloudSdkTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
-    checkCloudSdkTask.setToolsExtension(toolsExtension);
 
     when(cloudSdkBuilderFactory.newBuilder()).thenReturn(builder);
     when(builder.build()).thenReturn(sdk);
   }
 
   @Test
-  public void testCheckCloudSdkAction_nullHome() {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(null);
-
-    try {
-      checkCloudSdkTask.checkCloudSdkAction();
-      Assert.fail();
-    } catch (GradleException ex) {
-      Assert.assertEquals("SDK home directory must be specified for validation.", ex.getMessage());
-    }
-  }
-
-  @Test
   public void testCheckCloudSdkAction_nullVersion() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-    when(toolsExtension.getCloudSdkVersion()).thenReturn(null);
-
+    checkCloudSdkTask.setVersion(null);
     try {
       checkCloudSdkTask.checkCloudSdkAction();
       Assert.fail();
     } catch (GradleException ex) {
-      Assert.assertEquals("SDK version must be specified for validation.", ex.getMessage());
+      Assert.assertEquals(
+          "Cloud SDK home path and version must be configured in order to run this task.",
+          ex.getMessage());
     }
   }
 
   @Test
   public void testCheckCloudSdkAction_versionMismatch() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-
-    when(toolsExtension.getCloudSdkVersion()).thenReturn("191.0.0");
+    checkCloudSdkTask.setVersion("191.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("190.0.0"));
-
     try {
       checkCloudSdkTask.checkCloudSdkAction();
       Assert.fail();
@@ -109,8 +92,7 @@ public class CheckCloudSdkTaskTest {
 
   @Test
   public void testCheckCloudSdkAction_sdkInstallationException() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-    when(toolsExtension.getCloudSdkVersion()).thenReturn("192.0.0");
+    checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
     doThrow(CloudSdkNotFoundException.class).when(sdk).validateCloudSdk();
@@ -124,8 +106,7 @@ public class CheckCloudSdkTaskTest {
 
   @Test
   public void testCheckCloudSdkAction_outOfDateException() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-    when(toolsExtension.getCloudSdkVersion()).thenReturn("192.0.0");
+    checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
     doThrow(CloudSdkOutOfDateException.class).when(sdk).validateCloudSdk();
@@ -139,8 +120,7 @@ public class CheckCloudSdkTaskTest {
 
   @Test
   public void testCheckCloudSdkAction_versionFileException() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-    when(toolsExtension.getCloudSdkVersion()).thenReturn("192.0.0");
+    checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
     doThrow(CloudSdkVersionFileException.class).when(sdk).validateCloudSdk();
@@ -154,8 +134,7 @@ public class CheckCloudSdkTaskTest {
 
   @Test
   public void testCheckCloudSdkAction_appEngineInstallationExceptions() throws IOException {
-    when(toolsExtension.getCloudSdkHome()).thenReturn(temporaryFolder.newFolder());
-    when(toolsExtension.getCloudSdkVersion()).thenReturn("192.0.0");
+    checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
     doThrow(AppEngineJavaComponentsNotInstalledException.class)

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTaskTest.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkVersionFileException;
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
-import java.io.IOException;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskExecutionException;
@@ -64,7 +63,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_nullVersion() throws IOException {
+  public void testCheckCloudSdkAction_nullVersion() {
     checkCloudSdkTask.setVersion(null);
     try {
       checkCloudSdkTask.checkCloudSdkAction();
@@ -77,7 +76,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_versionMismatch() throws IOException {
+  public void testCheckCloudSdkAction_versionMismatch() {
     checkCloudSdkTask.setVersion("191.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("190.0.0"));
     try {
@@ -91,7 +90,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_sdkInstallationException() throws IOException {
+  public void testCheckCloudSdkAction_sdkInstallationException() {
     checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
@@ -105,7 +104,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_outOfDateException() throws IOException {
+  public void testCheckCloudSdkAction_outOfDateException() {
     checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
@@ -119,7 +118,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_versionFileException() throws IOException {
+  public void testCheckCloudSdkAction_versionFileException() {
     checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 
@@ -133,7 +132,7 @@ public class CheckCloudSdkTaskTest {
   }
 
   @Test
-  public void testCheckCloudSdkAction_appEngineInstallationExceptions() throws IOException {
+  public void testCheckCloudSdkAction_appEngineInstallationExceptions() {
     checkCloudSdkTask.setVersion("192.0.0");
     when(sdk.getVersion()).thenReturn(new CloudSdkVersion("192.0.0"));
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskTest.java
@@ -21,11 +21,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.managedcloudsdk.BadCloudSdkVersionException;
 import com.google.cloud.tools.managedcloudsdk.ManagedCloudSdk;
 import com.google.cloud.tools.managedcloudsdk.ManagedSdkVerificationException;
 import com.google.cloud.tools.managedcloudsdk.ManagedSdkVersionMismatchException;
-import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException;
 import com.google.cloud.tools.managedcloudsdk.command.CommandExitException;
 import com.google.cloud.tools.managedcloudsdk.components.SdkComponent;
@@ -34,7 +32,6 @@ import com.google.cloud.tools.managedcloudsdk.install.SdkInstaller;
 import com.google.cloud.tools.managedcloudsdk.install.SdkInstallerException;
 import com.google.cloud.tools.managedcloudsdk.update.SdkUpdater;
 import java.io.IOException;
-import java.nio.file.Paths;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
@@ -48,9 +45,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DownloadCloudSdkTaskTest {
 
-  @Mock private CloudSdkBuilderFactory cloudSdkBuilderFactory;
   @Mock private ManagedCloudSdk managedCloudSdk;
-  @Mock private ManagedCloudSdkFactory managedCloudSdkFactory;
 
   @Mock private SdkInstaller installer;
   @Mock private SdkComponentInstaller componentInstaller;
@@ -62,26 +57,22 @@ public class DownloadCloudSdkTaskTest {
 
   /** Setup DownloadCloudSdkTaskTest. */
   @Before
-  public void setup() throws UnsupportedOsException, BadCloudSdkVersionException {
+  public void setup() {
     Project tempProject = ProjectBuilder.builder().build();
     downloadCloudSdkTask =
         tempProject.getTasks().create("tempDownloadTask", DownloadCloudSdkTask.class);
-    downloadCloudSdkTask.setCloudSdkBuilderFactory(cloudSdkBuilderFactory);
-    downloadCloudSdkTask.setManagedCloudSdkFactory(managedCloudSdkFactory);
+    downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
 
     when(managedCloudSdk.newInstaller()).thenReturn(installer);
     when(managedCloudSdk.newComponentInstaller()).thenReturn(componentInstaller);
     when(managedCloudSdk.newUpdater()).thenReturn(updater);
-    when(managedCloudSdk.getSdkHome()).thenReturn(Paths.get(""));
-
-    when(managedCloudSdkFactory.newManagedSdk()).thenReturn(managedCloudSdk);
   }
 
   @Test
   public void testDownloadCloudSdkAction_install()
-      throws UnsupportedOsException, BadCloudSdkVersionException, ManagedSdkVerificationException,
-          ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-          SdkInstallerException, IOException, CommandExitException {
+      throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
+          InterruptedException, CommandExecutionException, SdkInstallerException, IOException,
+          CommandExitException {
     when(managedCloudSdk.isInstalled()).thenReturn(false);
     downloadCloudSdkTask.downloadCloudSdkAction();
     verify(managedCloudSdk).newInstaller();
@@ -89,9 +80,9 @@ public class DownloadCloudSdkTaskTest {
 
   @Test
   public void testDownloadCloudSdkAction_installComponent()
-      throws UnsupportedOsException, BadCloudSdkVersionException, ManagedSdkVerificationException,
-          ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-          SdkInstallerException, IOException, CommandExitException {
+      throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
+          InterruptedException, CommandExecutionException, SdkInstallerException, IOException,
+          CommandExitException {
     when(managedCloudSdk.isInstalled()).thenReturn(true);
     when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(false);
     downloadCloudSdkTask.downloadCloudSdkAction();
@@ -101,9 +92,9 @@ public class DownloadCloudSdkTaskTest {
 
   @Test
   public void testDownloadCloudSdkAction_update()
-      throws UnsupportedOsException, BadCloudSdkVersionException, ManagedSdkVerificationException,
-          ManagedSdkVersionMismatchException, InterruptedException, CommandExecutionException,
-          SdkInstallerException, IOException, CommandExitException {
+      throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
+          InterruptedException, CommandExecutionException, SdkInstallerException, IOException,
+          CommandExitException {
     when(managedCloudSdk.isInstalled()).thenReturn(true);
     when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(true);
     when(managedCloudSdk.isUpToDate()).thenReturn(false);


### PR DESCRIPTION
Simplifies DownloadCloudSdkTask a bit and prevents extension parameters from being modified at execution time. Fixes #216, fixes #224.