### PR TITLE
Implement appengineRun integration test, fix deploy tests

### DIFF
--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -32,9 +32,9 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,13 +69,48 @@ public class AppEngineStandardPluginIntegrationTest {
 
   @Before
   public void setUp() throws IOException {
+    System.setProperty("deploy.read.appengine.web.xml", "true");
     FileUtils.copyDirectory(new File(testProjectSrcDirectory), testProjectDir.getRoot());
   }
 
-  @Ignore
+  @After
+  public void cleanup() {
+    System.clearProperty("deploy.read.appengine.web.xml");
+  }
+
   @Test
-  public void testDevAppServer_sync() {
-    // TODO : write test for devapp server running in synchronous mode
+  public void testDevAppServer_sync() throws IOException, InterruptedException {
+    Thread thread = new Thread(() -> {
+      try {
+        AssertConnection.assertResponseWithRetries(
+            "http://localhost:8080", 200, "Hello from the App Engine Standard project.", 60000);
+      } catch (InterruptedException ex) {
+        ex.printStackTrace();
+      } finally {
+        // stop server
+        try {
+          GradleRunner.create()
+              .withProjectDir(testProjectDir.getRoot())
+              .withPluginClasspath()
+              .withArguments("appengineStop")
+              .build();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+
+    GradleRunner.create()
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments("appengineRun")
+        .build();
+
+    thread.join();
+
+    AssertConnection.assertUnreachable("http://localhost:8080", 8000);
   }
 
   /**

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
@@ -60,14 +60,16 @@ public class AssertConnection {
     Assert.fail("ConnectException expected");
   }
 
-  public static void assertResponseWithRetries(String url, int expectedCode, String expectedText, long timeout)
-      throws InterruptedException {
+  /** Connect and assert response is as expected within a specified time interval. */
+  public static void assertResponseWithRetries(
+      String url, int expectedCode, String expectedText, long timeout) throws InterruptedException {
     long waitedMs = 0;
     while (waitedMs < timeout) {
       try {
         HttpURLConnection urlConnection = (HttpURLConnection) new URL(url).openConnection();
         int responseCode = urlConnection.getResponseCode();
-        String response = CharStreams.toString(new InputStreamReader(urlConnection.getInputStream()));
+        String response =
+            CharStreams.toString(new InputStreamReader(urlConnection.getInputStream()));
 
         // Will only reach this point when a response is reached
         Assert.assertEquals(expectedCode, responseCode);
@@ -77,9 +79,10 @@ public class AssertConnection {
       } catch (IOException ex) {
         // No response, wait 100ms and try again
         Thread.sleep(100);
-        waitedMs += 100;}
+        waitedMs += 100;
+      }
     }
 
-    Assert.fail("No response received.");
+    Assert.fail("No response received in specified time interval.");
   }
 }

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
@@ -59,4 +59,27 @@ public class AssertConnection {
     }
     Assert.fail("ConnectException expected");
   }
+
+  public static void assertResponseWithRetries(String url, int expectedCode, String expectedText, long timeout)
+      throws InterruptedException {
+    long waitedMs = 0;
+    while (waitedMs < timeout) {
+      try {
+        HttpURLConnection urlConnection = (HttpURLConnection) new URL(url).openConnection();
+        int responseCode = urlConnection.getResponseCode();
+        String response = CharStreams.toString(new InputStreamReader(urlConnection.getInputStream()));
+
+        // Will only reach this point when a response is reached
+        Assert.assertEquals(expectedCode, responseCode);
+        Assert.assertThat(response, CoreMatchers.equalTo(expectedText));
+        return;
+
+      } catch (IOException ex) {
+        // No response, wait 100ms and try again
+        Thread.sleep(100);
+        waitedMs += 100;}
+    }
+
+    Assert.fail("No response received.");
+  }
 }

--- a/src/integTest/resources/projects/flexible-project/build.gradle
+++ b/src/integTest/resources/projects/flexible-project/build.gradle
@@ -28,3 +28,9 @@ repositories {
 dependencies {
   compile "javax.servlet:servlet-api:2.5"
 }
+
+appengine {
+  deploy {
+    project "travis-app-maven-plugin"
+  }
+}

--- a/src/integTest/resources/projects/standard-project-java8/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/integTest/resources/projects/standard-project-java8/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>gcloud-fills-this-out</application>
+    <application>travis-app-maven-plugin</application>
     <version>1</version>
     <threadsafe>true</threadsafe>
     <runtime>java8</runtime>

--- a/src/integTest/resources/projects/standard-project/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/integTest/resources/projects/standard-project/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>gcloud-fills-this-out</application>
+    <application>travis-app-maven-plugin</application>
     <version>1</version>
     <threadsafe>true</threadsafe>
     <module>standard-project</module>


### PR DESCRIPTION
* Implemented appengineRun integration test, which is basically a mirror of the appengine:run integration test in the maven plugin.
* Fixed the deploy/deployAll integration tests to work again after the recent gcloud/appengine-web.xml changes.
* Since pretty much all the important tasks have integration/unit tests, gonna say this fixes #17.