### PR TITLE
Change appengineStop to not fail the build

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -24,6 +24,8 @@ import com.google.cloud.tools.gradle.appengine.util.io.FileOutputLineListener;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
@@ -34,6 +36,11 @@ public class DevAppServerStartTask extends DefaultTask {
   private CloudSdkBuilderFactory cloudSdkBuilderFactory;
   private DevAppServerHelper serverHelper = new DevAppServerHelper();
   private File devAppServerLoggingDir;
+
+  public DevAppServerStartTask() {
+    // force it to always run (required since we use OutputDirectory)
+    this.getOutputs().upToDateWhen(task -> false);
+  }
 
   public void setRunConfig(RunExtension runConfig) {
     this.runConfig = runConfig;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -24,8 +24,6 @@ import com.google.cloud.tools.gradle.appengine.util.io.FileOutputLineListener;
 import java.io.File;
 import java.io.IOException;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Task;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
@@ -48,8 +48,8 @@ public class DevAppServerStopTask extends DefaultTask {
     AppEngineDevServer server = serverHelper.getAppServer(sdk, runConfig);
     try {
       server.stop(serverHelper.getStopConfiguration(runConfig));
-    } catch (AppEngineException e) {
-      getLogger().warn("Failed to stop server: " + e.getMessage());
+    } catch (AppEngineException ex) {
+      getLogger().error("Failed to stop server: " + ex.getMessage());
     }
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine.standard;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.gradle.appengine.core.CloudSdkBuilderFactory;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
@@ -41,10 +42,14 @@ public class DevAppServerStopTask extends DefaultTask {
 
   /** Task entrypoint : Stop the dev appserver (get StopConfiguration from helper). */
   @TaskAction
-  public void stopAction() throws AppEngineException {
+  public void stopAction() throws CloudSdkNotFoundException {
     CloudSdk sdk = cloudSdkBuilderFactory.newBuilder(getLogger()).build();
 
     AppEngineDevServer server = serverHelper.getAppServer(sdk, runConfig);
-    server.stop(serverHelper.getStopConfiguration(runConfig));
+    try {
+      server.stop(serverHelper.getStopConfiguration(runConfig));
+    } catch (AppEngineException e) {
+      getLogger().warn("Failed to stop server: " + e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Useful when running ./gradlew appengineStop appengineStart
Fix appengineStart UP-TO-DATE checks