### PR TITLE
use dynamic property for projectAsService

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
@@ -24,6 +24,8 @@ import org.gradle.api.tasks.Sync;
 /** Expand a war. */
 public class ExplodeWarTask extends Sync {
 
+  // if you change this name, you must change how it is resolved dynamically in {@link
+  // RunExtension#projectAsService}
   private File explodedAppDirectory;
 
   public void setWarFile(File warFile) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
@@ -24,8 +24,6 @@ import org.gradle.api.tasks.Sync;
 /** Expand a war. */
 public class ExplodeWarTask extends Sync {
 
-  // if you change this name, you must change how it is resolved dynamically in {@link
-  // RunExtension#projectAsService}
   private File explodedAppDirectory;
 
   public void setWarFile(File warFile) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -317,9 +317,11 @@ public class RunExtension implements RunConfiguration {
         .getTasks()
         .findByName(AppEngineStandardPlugin.START_TASK_NAME)
         .dependsOn(serviceProject.getTasks().findByPath(BasePlugin.ASSEMBLE_TASK_NAME));
-    return ((ExplodeWarTask)
-            serviceProject.getTasks().findByName(AppEngineStandardPlugin.EXPLODE_WAR_TASK_NAME))
-        .getExplodedAppDirectory();
+    return (File)
+        serviceProject
+            .getTasks()
+            .findByName(AppEngineStandardPlugin.EXPLODE_WAR_TASK_NAME)
+            .property("explodedAppDirectory");
   }
 
   @Override

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -317,11 +317,12 @@ public class RunExtension implements RunConfiguration {
         .getTasks()
         .findByName(AppEngineStandardPlugin.START_TASK_NAME)
         .dependsOn(serviceProject.getTasks().findByPath(BasePlugin.ASSEMBLE_TASK_NAME));
-    return (File)
-        serviceProject
-            .getTasks()
-            .findByName(AppEngineStandardPlugin.EXPLODE_WAR_TASK_NAME)
-            .property("explodedAppDirectory");
+    return serviceProject
+        .getTasks()
+        .findByName(AppEngineStandardPlugin.EXPLODE_WAR_TASK_NAME)
+        .getOutputs()
+        .getFiles()
+        .getSingleFile();
   }
 
   @Override


### PR DESCRIPTION
project was erroring out when decorated task could not be converted to actual task type. This fixes the problem, ~~but means we have to be careful when changing the property name.~~

the war exploding task only has one output and we can reference that directly.