### PR TITLE
Correctly handle optional extraFilesDirectories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,5 +169,6 @@ checkstyle {
   config = resources.text.fromArchiveEntry(configurations.checkstyle[0], 'google_checks.xml')
   maxErrors = 0
   maxWarnings = 0
+  checkstyleTest.enabled = false
 }
 /* FORMATTING */

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineAppYamlPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineAppYamlPluginIntegrationTest.java
@@ -60,7 +60,6 @@ public class AppEngineAppYamlPluginIntegrationTest {
         GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withPluginClasspath()
-            .withDebug(true)
             .withArguments("appengineDeploy")
             .build();
 
@@ -79,7 +78,6 @@ public class AppEngineAppYamlPluginIntegrationTest {
         GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withPluginClasspath()
-            .withDebug(true)
             .withArguments("appengineDeployAll")
             .build();
 

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -173,7 +173,6 @@ public class AppEngineStandardPluginIntegrationTest {
         GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withPluginClasspath()
-            .withDebug(true)
             .withArguments("appengineDeploy", "--stacktrace")
             .build();
 
@@ -192,7 +191,6 @@ public class AppEngineStandardPluginIntegrationTest {
         GradleRunner.create()
             .withProjectDir(testProjectDir.getRoot())
             .withPluginClasspath()
-            .withDebug(true)
             .withArguments("appengineDeployAll")
             .build();
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -85,20 +85,20 @@ public class StageAppYamlExtension {
   /** This method is purely for incremental build calculations. */
   @Optional
   @InputFiles
-  public FileCollection calculateExtraFiles() {
+  private FileCollection convertExtraFilesDirectoriesToInputFiles() {
     if (extraFilesDirectories == null) {
       return null;
     }
     FileCollection files = project.files();
-    for (File f : extraFilesDirectories) {
-      files = files.plus(project.fileTree(f));
+    for (File directory : extraFilesDirectories) {
+      files = files.plus(project.fileTree(directory));
     }
     return files;
   }
 
   /**
    * extraFilesDirectory accessor, with {@code @InputFiles} for incremental builds configured on
-   * {@link StageAppYamlExtension#calculateExtraFiles()}.
+   * {@link StageAppYamlExtension#convertExtraFilesDirectoriesToInputFiles()}.
    */
   public List<File> getExtraFilesDirectories() {
     return extraFilesDirectories;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -22,10 +22,11 @@ import com.google.cloud.tools.gradle.appengine.util.NullSafe;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -38,7 +39,7 @@ public class StageAppYamlExtension {
   private File dockerDirectory;
   private File artifact;
   private File stagingDirectory;
-  private List<File> extraFilesDirectory;
+  private List<File> extraFilesDirectories;
 
   public StageAppYamlExtension(Project project) {
     this.project = project;
@@ -81,22 +82,37 @@ public class StageAppYamlExtension {
     this.stagingDirectory = project.file(stagingDirectory);
   }
 
+  /** This method is purely for incremental build calculations. */
   @Optional
-  @InputDirectory
-  public List<File> getExtraFilesDirectory() {
-    return extraFilesDirectory;
+  @InputFiles
+  public FileCollection calculateExtraFiles() {
+    if (extraFilesDirectories == null) {
+      return null;
+    }
+    FileCollection files = project.files();
+    for (File f : extraFilesDirectories) {
+      files = files.plus(project.fileTree(f));
+    }
+    return files;
   }
 
-  public void setExtraFilesDirectory(Object extraFilesDirectory) {
-    this.extraFilesDirectory = new ArrayList<>(project.files(extraFilesDirectory).getFiles());
+  /**
+   * extraFilesDirectory accessor, with {@code @InputFiles} for incremental builds configured on
+   * {@link StageAppYamlExtension#calculateExtraFiles()}.
+   */
+  public List<File> getExtraFilesDirectories() {
+    return extraFilesDirectories;
+  }
+
+  public void setExtraFilesDirectories(Object extraFilesDirectories) {
+    this.extraFilesDirectories = new ArrayList<>(project.files(extraFilesDirectories).getFiles());
   }
 
   AppYamlProjectStageConfiguration toStageArchiveConfiguration() {
     return AppYamlProjectStageConfiguration.builder(
             appEngineDirectory.toPath(), artifact.toPath(), stagingDirectory.toPath())
         .dockerDirectory(NullSafe.convert(dockerDirectory, File::toPath))
-        .extraFilesDirectories(
-            extraFilesDirectory.stream().map(File::toPath).collect(Collectors.toList()))
+        .extraFilesDirectories(NullSafe.convert(extraFilesDirectories, File::toPath))
         .build();
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
@@ -34,11 +34,17 @@ public class NullSafe {
    * @param converter the map function to apply
    * @param <S> type to convert from
    * @param <R> type to convert to
-   * @return A converted List with null values stripped out, or null if source is null
+   * @return A converted List with all pre-conversion and post-conversion null values removed. Can
+   *     return an empty list. Will return null if source is null.
    */
   public static <S, R> List<R> convert(List<S> source, Function<S, R> converter) {
     return (source == null)
         ? null
-        : source.stream().filter(Objects::nonNull).map(converter).collect(Collectors.toList());
+        : source
+            .stream()
+            .filter(Objects::nonNull)
+            .map(converter)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
@@ -16,11 +16,29 @@
 
 package com.google.cloud.tools.gradle.appengine.util;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class NullSafe {
 
   public static <S, R> R convert(S source, Function<S, R> converter) {
     return (source == null) ? null : converter.apply(source);
+  }
+
+  /**
+   * Convert a list of a given type using converter.
+   *
+   * @param source a list to convert
+   * @param converter the map function to apply
+   * @param <S> type to convert from
+   * @param <R> type to convert to
+   * @return A converted List with null values stripped out, or null if source is null
+   */
+  public static <S, R> List<R> convert(List<S> source, Function<S, R> converter) {
+    return (source == null)
+        ? null
+        : source.stream().filter(Objects::nonNull).map(converter).collect(Collectors.toList());
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.gradle.appengine.appyaml;
+
+import com.google.cloud.tools.appengine.configuration.AppYamlProjectStageConfiguration;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class StageAppYamlExtensionTest {
+
+  @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+  private Project testContextProject;
+  private File stagingDirectory;
+  private File appEngineDirectory;
+  private File artifact;
+  private File dockerDirectory;
+  private List<File> extraFilesDirectories;
+
+  @Before
+  public void setUpFiles() throws IOException {
+    stagingDirectory = testProjectDir.newFolder("stage");
+    appEngineDirectory = testProjectDir.newFolder("app");
+    artifact = testProjectDir.newFile("artifact");
+    dockerDirectory = testProjectDir.newFolder("docker");
+    extraFilesDirectories =
+        Arrays.asList(testProjectDir.newFolder("extra1"), testProjectDir.newFolder("extra2"));
+    testContextProject = ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+  }
+
+  @Test
+  public void testToStageArchiveConfiguration_allValuesSet() {
+    StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
+
+    extension.setStagingDirectory(stagingDirectory);
+    extension.setAppEngineDirectory(appEngineDirectory);
+    extension.setArtifact(artifact);
+    extension.setDockerDirectory(dockerDirectory);
+    extension.setExtraFilesDirectories(extraFilesDirectories);
+
+    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertEquals(
+        extraFilesDirectories.stream().map(File::toPath).collect(Collectors.toList()),
+        generatedConfig.getExtraFilesDirectory());
+  }
+
+  @Test
+  public void testToStageArchiveConfiguration_nullExtraFiles() {
+    StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
+
+    extension.setStagingDirectory(stagingDirectory);
+    extension.setAppEngineDirectory(appEngineDirectory);
+    extension.setArtifact(artifact);
+    extension.setDockerDirectory(dockerDirectory);
+    // extraFilesDirectories is not set (default = null)
+
+    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertNull(generatedConfig.getExtraFilesDirectory());
+  }
+
+  @Test
+  public void testToStageArchiveConfiguration_emptyExtraFiles() {
+    StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
+
+    extension.setStagingDirectory(stagingDirectory);
+    extension.setAppEngineDirectory(appEngineDirectory);
+    extension.setArtifact(artifact);
+    extension.setDockerDirectory(dockerDirectory);
+    extension.setExtraFilesDirectories(Collections.emptyList());
+
+    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertEquals(0, generatedConfig.getExtraFilesDirectory().size());
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/util/NullSafeTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/util/NullSafeTest.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.gradle.appengine.util;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,5 +37,33 @@ public class NullSafeTest {
     Path testPath = Paths.get("some/path");
     File expectedResult = testPath.toFile();
     Assert.assertEquals(expectedResult, NullSafe.convert(testPath, Path::toFile));
+  }
+
+  @Test
+  public void testConvert_listNull() {
+    List<File> testFile = null;
+    Assert.assertNull(NullSafe.convert(testFile, File::toPath));
+  }
+
+  @Test
+  public void testConvert_listWithNull() {
+    File file1 = new File("test/file1");
+    File file2 = new File("test/file2");
+    List<File> testFiles = Arrays.asList(file1, null, file2);
+
+    List<Path> expected = Arrays.asList(file1.toPath(), file2.toPath());
+
+    Assert.assertEquals(expected, NullSafe.convert(testFiles, File::toPath));
+  }
+
+  @Test
+  public void testConvert_list() {
+    File file1 = new File("test/file1");
+    File file2 = new File("test/file2");
+    List<File> testFiles = Arrays.asList(file1, file2);
+
+    List<Path> expected = Arrays.asList(file1.toPath(), file2.toPath());
+
+    Assert.assertEquals(expected, NullSafe.convert(testFiles, File::toPath));
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/util/NullSafeTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/util/NullSafeTest.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,6 +56,26 @@ public class NullSafeTest {
     List<Path> expected = Arrays.asList(file1.toPath(), file2.toPath());
 
     Assert.assertEquals(expected, NullSafe.convert(testFiles, File::toPath));
+  }
+
+  @Test
+  public void testConvert_listWithOnlyNull() {
+    List<File> testFiles = Arrays.asList(null, null);
+
+    List<Path> expected = Collections.emptyList();
+
+    Assert.assertEquals(expected, NullSafe.convert(testFiles, File::toPath));
+  }
+
+  @Test
+  public void testConvert_listWithConversionsToNull() {
+    File file1 = new File("test/file1");
+    File file2 = new File("test/file2");
+    List<File> testFiles = Arrays.asList(file1, file2, null);
+
+    List<Path> expected = Collections.emptyList();
+
+    Assert.assertEquals(expected, NullSafe.convert(testFiles, (Function<File, Path>) file -> null));
   }
 
   @Test


### PR DESCRIPTION
- also removes gradle debug config from integration tests (causing
failures for no reason)
- removes checkstyle from test sources