### PR TITLE
Only download java components when required

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
@@ -55,7 +55,8 @@ public class AppEngineAppYamlPlugin implements Plugin<Project> {
     appengineExtension.createSubExtensions(project);
 
     new AppEngineCorePluginConfiguration()
-        .configureCoreProperties(project, appengineExtension, APP_ENGINE_APP_YAML_TASK_GROUP);
+        .configureCoreProperties(
+            project, appengineExtension, APP_ENGINE_APP_YAML_TASK_GROUP, false);
 
     configureExtensions();
     createStageTask();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -52,13 +52,15 @@ public class AppEngineCorePluginConfiguration {
   private ToolsExtension toolsExtension;
   private CloudSdkOperations cloudSdkOperations;
   private ManagedCloudSdk managedCloudSdk;
+  private boolean requiresAppEngineJava;
   private String taskGroup;
 
   /** Configure core tasks for appengine app.yaml and appengine-web.xml based project plugins. */
   public void configureCoreProperties(
       Project project,
       AppEngineCoreExtensionProperties appEngineCoreExtensionProperties,
-      String taskGroup) {
+      String taskGroup,
+      boolean requiresAppEngineJava) {
     project
         .getLogger()
         .warn(
@@ -78,6 +80,7 @@ public class AppEngineCorePluginConfiguration {
     this.taskGroup = taskGroup;
     this.toolsExtension = appEngineCoreExtensionProperties.getTools();
     this.deployExtension = appEngineCoreExtensionProperties.getDeploy();
+    this.requiresAppEngineJava = requiresAppEngineJava;
     configureFactories();
 
     createDownloadCloudSdkTask();
@@ -134,6 +137,7 @@ public class AppEngineCorePluginConfiguration {
             downloadCloudSdkTask -> {
               downloadCloudSdkTask.setGroup(taskGroup);
               downloadCloudSdkTask.setDescription("Download the Cloud SDK");
+              downloadCloudSdkTask.requiresAppEngineJava(requiresAppEngineJava);
 
               project.afterEvaluate(
                   p -> {
@@ -162,6 +166,7 @@ public class AppEngineCorePluginConfiguration {
                     if (managedCloudSdk == null && toolsExtension.getCloudSdkVersion() != null) {
                       checkCloudSdkTask.setVersion(toolsExtension.getCloudSdkVersion());
                       checkCloudSdkTask.setCloudSdk(cloudSdkOperations.getCloudSdk());
+                      checkCloudSdkTask.requiresAppEngineJava(requiresAppEngineJava);
                       p.getTasks()
                           .matching(task -> task.getName().startsWith("appengine"))
                           .forEach(task -> task.dependsOn(checkCloudSdkTask));

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.appengine.operations.cloudsdk.AppEngineJavaCompone
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkVersionFileException;
-import com.google.cloud.tools.appengine.operations.cloudsdk.InvalidJavaSdkException;
 import com.google.common.base.Strings;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -32,6 +31,7 @@ public class CheckCloudSdkTask extends DefaultTask {
 
   private CloudSdk cloudSdk;
   private String version;
+  private boolean requiresAppEngineJava;
 
   public void setVersion(String version) {
     this.version = version;
@@ -41,11 +41,15 @@ public class CheckCloudSdkTask extends DefaultTask {
     this.cloudSdk = cloudSdk;
   }
 
+  public void requiresAppEngineJava(boolean requiresAppEngineJava) {
+    this.requiresAppEngineJava = requiresAppEngineJava;
+  }
+
   /** Task entrypoint : Verify Cloud SDK installation. */
   @TaskAction
   public void checkCloudSdkAction()
-      throws CloudSdkNotFoundException, CloudSdkVersionFileException, InvalidJavaSdkException,
-          CloudSdkOutOfDateException, AppEngineJavaComponentsNotInstalledException {
+      throws CloudSdkNotFoundException, CloudSdkVersionFileException, CloudSdkOutOfDateException,
+          AppEngineJavaComponentsNotInstalledException {
     // These properties are only set by AppEngineCorePluginConfiguration if the correct config
     // params are set in the tools extension.
     if (Strings.isNullOrEmpty(version) || cloudSdk == null) {
@@ -63,6 +67,8 @@ public class CheckCloudSdkTask extends DefaultTask {
     }
 
     cloudSdk.validateCloudSdk();
-    cloudSdk.validateAppEngineJavaComponents();
+    if (requiresAppEngineJava) {
+      cloudSdk.validateAppEngineJavaComponents();
+    }
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
@@ -34,8 +34,6 @@ public class CloudSdkOperations {
 
   private final CloudSdk cloudSdk;
   private final Gcloud gcloud;
-  private final LocalRun localRun;
-  private final AppCfg appcfg;
 
   /**
    * Operations factory for Cloud Sdk based actions.
@@ -47,7 +45,6 @@ public class CloudSdkOperations {
   public CloudSdkOperations(File cloudSdkHome, File credentialFile)
       throws CloudSdkNotFoundException {
     cloudSdk = new CloudSdk.Builder().sdkPath(cloudSdkHome.toPath()).build();
-    localRun = LocalRun.builder(cloudSdk).build();
     gcloud =
         Gcloud.builder(cloudSdk)
             .setCredentialFile(NullSafe.convert(credentialFile, File::toPath))
@@ -55,7 +52,6 @@ public class CloudSdkOperations {
                 getClass().getPackage().getImplementationTitle(),
                 getClass().getPackage().getImplementationVersion())
             .build();
-    appcfg = AppCfg.builder(cloudSdk).build();
   }
 
   public CloudSdk getCloudSdk() {
@@ -66,12 +62,20 @@ public class CloudSdkOperations {
     return gcloud;
   }
 
+  /**
+   * LocalRun isn't initialized at construction time, because we optionally download the appengine
+   * component for appengine-web.xml based applications
+   */
   public LocalRun getLocalRun() {
-    return localRun;
+    return LocalRun.builder(cloudSdk).build();
   }
 
+  /**
+   * AppCfg isn't initialized at construction time, because we optionally download the appengine
+   * component for appengine-web.xml based applications
+   */
   public AppCfg getAppcfg() {
-    return appcfg;
+    return AppCfg.builder(cloudSdk).build();
   }
 
   /** Create a return a new default configured process handler. */

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -37,9 +37,14 @@ import org.gradle.api.tasks.TaskAction;
 public class DownloadCloudSdkTask extends DefaultTask {
 
   private ManagedCloudSdk managedCloudSdk;
+  private boolean requiresAppEngineJava;
 
   public void setManagedCloudSdk(ManagedCloudSdk managedCloudSdk) {
     this.managedCloudSdk = managedCloudSdk;
+  }
+
+  public void requiresAppEngineJava(boolean requiresAppEngineJava) {
+    this.requiresAppEngineJava = requiresAppEngineJava;
   }
 
   /** Task entrypoint : Download/update Cloud SDK. */
@@ -62,11 +67,13 @@ public class DownloadCloudSdkTask extends DefaultTask {
       installer.install(progressListener, consoleListener);
     }
 
-    // Install app engine component
-    if (!managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)) {
-      SdkComponentInstaller componentInstaller = managedCloudSdk.newComponentInstaller();
-      componentInstaller.installComponent(
-          SdkComponent.APP_ENGINE_JAVA, progressListener, consoleListener);
+    // optionally Install app engine component
+    if (requiresAppEngineJava) {
+      if (!managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)) {
+        SdkComponentInstaller componentInstaller = managedCloudSdk.newComponentInstaller();
+        componentInstaller.installComponent(
+            SdkComponent.APP_ENGINE_JAVA, progressListener, consoleListener);
+      }
     }
 
     // If version is set to LATEST, update Cloud SDK

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -71,7 +71,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
 
     appEngineCorePluginConfiguration = new AppEngineCorePluginConfiguration();
     appEngineCorePluginConfiguration.configureCoreProperties(
-        project, appengineExtension, APP_ENGINE_STANDARD_TASK_GROUP);
+        project, appengineExtension, APP_ENGINE_STANDARD_TASK_GROUP, true);
 
     explodedWarDir = new File(project.getBuildDir(), "exploded-" + project.getName());
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskTest.java
@@ -97,11 +97,25 @@ public class DownloadCloudSdkTaskTest {
           InterruptedException, CommandExecutionException, SdkInstallerException, IOException,
           CommandExitException {
     downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
+    downloadCloudSdkTask.requiresAppEngineJava(true);
     when(managedCloudSdk.isInstalled()).thenReturn(true);
     when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(false);
     downloadCloudSdkTask.downloadCloudSdkAction();
     verify(managedCloudSdk, never()).newInstaller();
     verify(managedCloudSdk).newComponentInstaller();
+  }
+
+  @Test
+  public void testDownloadCloudSdkAction_skipInstallComponent()
+      throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,
+          InterruptedException, CommandExecutionException, SdkInstallerException, IOException,
+          CommandExitException {
+    downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
+    downloadCloudSdkTask.requiresAppEngineJava(false);
+    when(managedCloudSdk.isInstalled()).thenReturn(true);
+    downloadCloudSdkTask.downloadCloudSdkAction();
+    verify(managedCloudSdk, never()).newInstaller();
+    verify(managedCloudSdk, never()).newComponentInstaller();
   }
 
   @Test
@@ -111,7 +125,6 @@ public class DownloadCloudSdkTaskTest {
           CommandExitException {
     downloadCloudSdkTask.setManagedCloudSdk(managedCloudSdk);
     when(managedCloudSdk.isInstalled()).thenReturn(true);
-    when(managedCloudSdk.hasComponent(SdkComponent.APP_ENGINE_JAVA)).thenReturn(true);
     when(managedCloudSdk.isUpToDate()).thenReturn(false);
     downloadCloudSdkTask.downloadCloudSdkAction();
     verify(managedCloudSdk, never()).newInstaller();


### PR DESCRIPTION
Should be pretty close to the last of our appengine plugin changes.

Not super fond of using the flag to indicate whether to download the appengine components or not, but providing the cleanest solution would probably require a larger rewrite.