### PR TITLE
Set up Travix matrix to add JDK 11 build / upgrade plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - name: Oracle JDK 8
+      jdk: oraclejdk8
+    - name: OpenJDK 11
+      jdk: openjdk11
 
 before_cache:
   - rm -rf $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-library:1.3'
-  testCompile 'org.mockito:mockito-core:2.7.21'
+  testCompile 'org.mockito:mockito-core:2.23.4'
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
   id 'maven'
   id 'java-gradle-plugin'
   id 'net.researchgate.release' version '2.6.0'
-  id 'com.github.sherter.google-java-format' version '0.7.1'
+  id 'com.github.sherter.google-java-format' version '0.8'
   id 'checkstyle'
 }
 

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPluginIntegrationTest.java
@@ -30,7 +30,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.util.FileUtils;
-import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -46,7 +45,7 @@ public class SourceContextPluginIntegrationTest {
   public void setUpTestProject() throws IOException {
     Path buildFile = testProjectDir.getRoot().toPath().resolve("build.gradle");
 
-    Path src = Files.createDirectory(testProjectDir.getRoot().toPath().resolve("src"));
+    Files.createDirectory(testProjectDir.getRoot().toPath().resolve("src"));
     InputStream buildFileContent =
         getClass()
             .getClassLoader()
@@ -89,12 +88,11 @@ public class SourceContextPluginIntegrationTest {
   @Test
   public void testCreateSourceContext() throws IOException {
     setUpTestProject();
-    BuildResult buildResult =
-        GradleRunner.create()
-            .withProjectDir(testProjectDir.getRoot())
-            .withPluginClasspath()
-            .withArguments(":assemble")
-            .build();
+    GradleRunner.create()
+        .withProjectDir(testProjectDir.getRoot())
+        .withPluginClasspath()
+        .withArguments(":assemble")
+        .build();
 
     String commitHash = "9a282640c4a91769d328bbf23e8d8b2b5dcbbb5b";
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ShowConfigurationTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ShowConfigurationTask.java
@@ -121,11 +121,11 @@ public class ShowConfigurationTask extends DefaultTask {
     if (genericType != null && genericType instanceof ParameterizedType) {
       for (Type t : ((ParameterizedType) genericType).getActualTypeArguments()) {
         if (t instanceof ParameterizedType) {
-          String nestedGeneric = ((Class) ((ParameterizedType) t).getRawType()).getSimpleName();
+          String nestedGeneric = ((Class<?>) ((ParameterizedType) t).getRawType()).getSimpleName();
           nestedGeneric += getGenericTypeData(t);
           types.add(nestedGeneric);
         } else {
-          types.add(((Class) t).getSimpleName());
+          types.add(((Class<?>) t).getSimpleName());
         }
       }
     }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
@@ -20,7 +20,6 @@ package com.google.cloud.tools.gradle.appengine.standard;
 import com.google.cloud.tools.appengine.AppEngineException;
 import com.google.cloud.tools.appengine.operations.DevServer;
 import com.google.cloud.tools.appengine.operations.LocalRun;
-import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
@@ -42,7 +41,7 @@ public class DevAppServerStopTask extends DefaultTask {
 
   /** Task entrypoint : Stop the dev appserver (get StopConfiguration from helper). */
   @TaskAction
-  public void stopAction() throws CloudSdkNotFoundException {
+  public void stopAction() {
     DevServer server =
         serverHelper.getAppServer(
             localRun, runConfig, CloudSdkOperations.getDefaultHandler(getLogger()));

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.appyaml.AppEngineAppYamlPlugin;
 import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfiguration;
@@ -39,8 +40,13 @@ public class AppEnginePluginTest {
 
   @Rule public TemporaryFolder testProjectRoot = new TemporaryFolder();
 
+  private boolean isJava8Runtime() {
+    return System.getProperty("java.version").startsWith("1.8");
+  }
+
   @Test
   public void testCheckGradleVersion_pass() {
+    assumeTrue(isJava8Runtime());
     new TestProject(testProjectRoot.getRoot())
         .applyGradleRunnerWithGradleVersion(
             AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
@@ -49,6 +55,7 @@ public class AppEnginePluginTest {
 
   @Test
   public void testCheckGradleVersion_fail() throws IOException {
+    assumeTrue(isJava8Runtime());
     try {
       new TestProject(testProjectRoot.getRoot())
           .addAutoDownloadingBuildFile()
@@ -105,7 +112,7 @@ public class AppEnginePluginTest {
   }
 
   @Test
-  public void testDetectAppYaml_withProjectBuilder() throws IOException {
+  public void testDetectAppYaml_withProjectBuilder() {
     Project p = new TestProject(testProjectRoot.getRoot()).applyAutoDetectingProjectBuilder();
 
     assertAppYaml(p);
@@ -122,7 +129,7 @@ public class AppEnginePluginTest {
   }
 
   @Test
-  public void testDetectAppYaml_withFallbackNegative() throws IOException {
+  public void testDetectAppYaml_withFallbackNegative() {
     Project p =
         new TestProject(testProjectRoot.getRoot())
             .applyAutoDetectingProjectBuilderWithFallbackTrigger();

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/TestProject.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/TestProject.java
@@ -100,7 +100,7 @@ public class TestProject {
   }
 
   /** Add an empty docker directory. */
-  public TestProject addDockerDir() throws IOException {
+  public TestProject addDockerDir() {
     File dockerDir = new File(projectRoot, "src/main/docker");
     if (!dockerDir.mkdirs()) {
       throw new RuntimeException("Test failed due to directory creation error");
@@ -127,31 +127,31 @@ public class TestProject {
   }
 
   /** Run the project builder and return an evaluated project. */
-  public Project applyStandardProjectBuilder() throws IOException {
+  public Project applyStandardProjectBuilder() {
     return applyProjectBuilder(JavaPlugin.class, WarPlugin.class, AppEngineStandardPlugin.class);
   }
 
   /** Run the project builder and return an evaluated project. */
-  public Project applyAppYamlProjectBuilder() throws IOException {
+  public Project applyAppYamlProjectBuilder() {
     return applyProjectBuilder(JavaPlugin.class, AppEngineAppYamlPlugin.class);
   }
 
   /** Run the project builder and return an evaluated project. */
-  public Project applyAppYamlWarProjectBuilder() throws IOException {
+  public Project applyAppYamlWarProjectBuilder() {
     return applyProjectBuilder(JavaPlugin.class, WarPlugin.class, AppEngineAppYamlPlugin.class);
   }
 
   /** Run the project builder and return an evaluated project. */
-  public Project applyAutoDetectingProjectBuilder() throws IOException {
+  public Project applyAutoDetectingProjectBuilder() {
     return applyProjectBuilder(JavaPlugin.class, WarPlugin.class, AppEnginePlugin.class);
   }
 
   /** Run the project builder and return an evaluated project. */
-  public Project applyAutoDetectingProjectBuilderWithFallbackTrigger() throws IOException {
+  public Project applyAutoDetectingProjectBuilderWithFallbackTrigger() {
     return applyProjectBuilder(JavaPlugin.class, AppEnginePlugin.class, WarPlugin.class);
   }
 
-  private Project applyProjectBuilder(Class<?>... plugins) throws IOException {
+  private Project applyProjectBuilder(Class<?>... plugins) {
     Project p = ProjectBuilder.builder().withProjectDir(projectRoot).build();
     for (Class<?> clazz : plugins) {
       p.getPluginManager().apply(clazz);

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.BuildResultFilter;
 import com.google.cloud.tools.gradle.appengine.TestProject;
@@ -45,6 +46,10 @@ public class AppEngineAppYamlPluginTest {
 
   @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
+  private static boolean isJava8Runtime() {
+    return System.getProperty("java.version").startsWith("1.8");
+  }
+
   private TestProject createTestProject() throws IOException {
     return new TestProject(testProjectDir.getRoot()).addAppYamlBuildFile();
   }
@@ -55,6 +60,7 @@ public class AppEngineAppYamlPluginTest {
 
   @Test
   public void testCheckGradleVersion_pass() throws IOException {
+    assumeTrue(isJava8Runtime());
     createTestProject()
         .applyGradleRunnerWithGradleVersion(
             AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
@@ -63,6 +69,7 @@ public class AppEngineAppYamlPluginTest {
 
   @Test
   public void testCheckGradleVersion_fail() throws IOException {
+    assumeTrue(isJava8Runtime());
     try {
       createTestProject().applyGradleRunnerWithGradleVersion("2.8");
     } catch (UnexpectedBuildFailure ex) {
@@ -188,7 +195,7 @@ public class AppEngineAppYamlPluginTest {
   }
 
   @Test
-  public void testDefaultConfigurationAlternative() throws IOException {
+  public void testDefaultConfigurationAlternative() {
     Project p =
         new TestProject(testProjectDir.getRoot()).addDockerDir().applyAppYamlProjectBuilder();
 
@@ -200,7 +207,7 @@ public class AppEngineAppYamlPluginTest {
   }
 
   @Test
-  public void testAppEngineTaskGroupAssignment() throws IOException {
+  public void testAppEngineTaskGroupAssignment() {
     Project p = new TestProject(testProjectDir.getRoot()).applyAppYamlProjectBuilder();
 
     p.getTasks()

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolverTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolverTest.java
@@ -38,8 +38,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppYamlDeployTargetResolverTest {
-  private static final String PROJECT_XML = "project-xml";
-  private static final String VERSION_XML = "version-xml";
   private static final String PROJECT_GCLOUD = "project-gcloud";
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTaskTest.java
@@ -58,7 +58,7 @@ public class DeployAllTaskTest {
 
   /** Setup DeployAllTaskTest. */
   @Before
-  public void setup() throws IOException, AppEngineException {
+  public void setup() throws IOException {
     Project tempProject = ProjectBuilder.builder().build();
     deployConfig = new DeployExtension(tempProject);
     deployCapture = ArgumentCaptor.forClass(DeployConfiguration.class);

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPluginTest.java
@@ -52,7 +52,7 @@ public class SourceContextPluginTest {
   private void setUpTestProject() throws IOException {
     Path buildFile = testProjectDir.getRoot().toPath().resolve("build.gradle");
 
-    Path src = Files.createDirectory(testProjectDir.getRoot().toPath().resolve("src"));
+    Files.createDirectory(testProjectDir.getRoot().toPath().resolve("src"));
     InputStream buildFileContent =
         getClass()
             .getClassLoader()

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.BuildResultFilter;
 import com.google.cloud.tools.gradle.appengine.TestProject;
@@ -43,6 +44,10 @@ public class AppEngineStandardPluginTest {
 
   @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
 
+  private static boolean isJava8Runtime() {
+    return System.getProperty("java.version").startsWith("1.8");
+  }
+
   private TestProject createTestProject() throws IOException {
     return new TestProject(testProjectDir.getRoot()).addStandardBuildFile().addAppEngineWebXml();
   }
@@ -61,6 +66,7 @@ public class AppEngineStandardPluginTest {
 
   @Test
   public void testCheckGradleVersion_pass() throws IOException {
+    assumeTrue(isJava8Runtime());
     createTestProject()
         .applyGradleRunnerWithGradleVersion(
             AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
@@ -69,6 +75,7 @@ public class AppEngineStandardPluginTest {
 
   @Test
   public void testCheckGradleVersion_fail() throws IOException {
+    assumeTrue(isJava8Runtime());
     try {
       createTestProject().applyGradleRunnerWithGradleVersion("2.8");
     } catch (UnexpectedBuildFailure ex) {

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTaskTest.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.gradle.appengine.TestProject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.gradle.testkit.runner.BuildResult;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,11 +32,10 @@ public class ExplodeWarTaskTest {
 
   @Test
   public void testSyncTask() throws IOException {
-    BuildResult buildResult =
-        new TestProject(testProjectDir.getRoot())
-            .addStandardBuildFile()
-            .addAppEngineWebXml()
-            .applyGradleRunner("explodeWar");
+    new TestProject(testProjectDir.getRoot())
+        .addStandardBuildFile()
+        .addAppEngineWebXml()
+        .applyGradleRunner("explodeWar");
 
     Path explodedApp =
         testProjectDir

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
@@ -96,11 +96,11 @@ public class StandardDeployTargetResolverTest {
   }
 
   @Test
-  public void testGetProject_nothingSet() throws IOException {
+  public void testGetProject_nothingSet() {
     StandardDeployTargetResolver deployTargetResolver =
         new StandardDeployTargetResolver(appengineWebXml, gcloud);
     try {
-      String result = deployTargetResolver.getProject(null);
+      deployTargetResolver.getProject(null);
       Assert.fail();
     } catch (GradleException ex) {
       Assert.assertEquals(StandardDeployTargetResolver.PROJECT_ERROR, ex.getMessage());
@@ -132,7 +132,7 @@ public class StandardDeployTargetResolverTest {
   }
 
   @Test
-  public void testGetVersion_nothingSet() throws IOException {
+  public void testGetVersion_nothingSet() {
     StandardDeployTargetResolver deployTargetResolver =
         new StandardDeployTargetResolver(appengineWebXml, gcloud);
     try {


### PR DESCRIPTION
- JDK 11 build matrix on Travis
- `assumeTrue(Java8)` for some tests that can only run on Java 8.
- Upgrades various plugins
- Remove various warnings

Looks like I don't need Gradle 5.0 when not targeting Java 11.