### PR TITLE
Fix UP-TO-DATE annotations

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -27,6 +27,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -85,7 +86,7 @@ public class StageAppYamlExtension {
   /** This method is purely for incremental build calculations. */
   @Optional
   @InputFiles
-  private FileCollection convertExtraFilesDirectoriesToInputFiles() {
+  private FileCollection getExtraFilesDirectoriesAsInputFiles() {
     if (extraFilesDirectories == null) {
       return null;
     }
@@ -96,10 +97,7 @@ public class StageAppYamlExtension {
     return files;
   }
 
-  /**
-   * extraFilesDirectory accessor, with {@code @InputFiles} for incremental builds configured on
-   * {@link StageAppYamlExtension#convertExtraFilesDirectoriesToInputFiles()}.
-   */
+  @Internal("covered by getExtraFilesDirectoriesAsInputFiles")
   public List<File> getExtraFilesDirectories() {
     return extraFilesDirectories;
   }
@@ -108,7 +106,7 @@ public class StageAppYamlExtension {
     this.extraFilesDirectories = new ArrayList<>(project.files(extraFilesDirectories).getFiles());
   }
 
-  AppYamlProjectStageConfiguration toStageArchiveConfiguration() {
+  AppYamlProjectStageConfiguration toAppYamlProjectStageConfiguration() {
     return AppYamlProjectStageConfiguration.builder(
             appEngineDirectory.toPath(), artifact.toPath(), stagingDirectory.toPath())
         .dockerDirectory(NullSafe.convert(dockerDirectory, File::toPath))

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -86,7 +86,7 @@ public class StageAppYamlExtension {
   /** This method is purely for incremental build calculations. */
   @Optional
   @InputFiles
-  private FileCollection getExtraFilesDirectoriesAsInputFiles() {
+  public FileCollection getExtraFilesDirectoriesAsInputFiles() {
     if (extraFilesDirectories == null) {
       return null;
     }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
@@ -44,6 +44,6 @@ public class StageAppYamlTask extends DefaultTask {
     getProject().mkdir(appYamlExtension.getStagingDirectory().getAbsolutePath());
 
     AppYamlProjectStaging staging = new AppYamlProjectStaging();
-    staging.stageArchive(appYamlExtension.toStageArchiveConfiguration());
+    staging.stageArchive(appYamlExtension.toAppYamlProjectStageConfiguration());
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -67,7 +68,7 @@ public class StageStandardExtension {
     this.stagingDirectory = project.file(stagingDirectory);
   }
 
-  @Input
+  @InputFile
   @Optional
   public File getDockerfile() {
     return dockerfile;

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/TestProject.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/TestProject.java
@@ -77,6 +77,14 @@ public class TestProject {
     return this;
   }
 
+  /** Add a appyaml based appengine-gradle-plugin build file that specifies sdk home and version. */
+  public TestProject addAppYamlBuildFileWithExtraFilesDirectories() throws IOException {
+    addBuildFile("projects/AppEnginePluginTest/build-appyaml-extraFilesDirectories.gradle");
+    Files.createDirectories(
+        getProjectRoot().toPath().resolve("src").resolve("main").resolve("extras"));
+    return this;
+  }
+
   /** Add an generic appengine-gradle-plugin build file (for auto downloading sdk cases). */
   public TestProject addAutoDownloadingBuildFile() throws IOException {
     addBuildFile("projects/AppEnginePluginTest/build-auto.gradle");
@@ -93,9 +101,18 @@ public class TestProject {
   public TestProject addAppEngineWebXml() throws IOException {
     Path webInf = projectRoot.toPath().resolve("src/main/webapp/WEB-INF");
     Files.createDirectories(webInf);
-    File appengineWebXml = Files.createFile(webInf.resolve("appengine-web.xml")).toFile();
-    Files.write(appengineWebXml.toPath(), "<appengine-web-app/>".getBytes(Charsets.UTF_8));
+    Path appengineWebXml = Files.createFile(webInf.resolve("appengine-web.xml"));
+    Files.write(appengineWebXml, "<appengine-web-app/>".getBytes(Charsets.UTF_8));
 
+    return this;
+  }
+
+  /** Add a minimal app.yaml file to the standard location. */
+  public TestProject addAppYaml(String runtime) throws IOException {
+    Path appengineDir = projectRoot.toPath().resolve("src").resolve("main").resolve("appengine");
+    Files.createDirectories(appengineDir);
+    Path appyaml = Files.createFile(appengineDir.resolve("app.yaml"));
+    Files.write(appyaml, ("runtime: " + runtime).getBytes(Charsets.UTF_8));
     return this;
   }
 
@@ -166,5 +183,9 @@ public class TestProject {
     ((ProjectInternal) p).evaluate();
 
     return p;
+  }
+
+  public File getProjectRoot() {
+    return projectRoot;
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
@@ -122,9 +122,10 @@ public class StageAppYamlExtensionTest {
 
   @Test
   public void testGetExtraFilesDirectoriesAsInputFiles_indirectFunctional() throws IOException {
-    TestProject testProject = new TestProject(testProjectDir.getRoot())
-        .addAppYamlBuildFileWithExtraFilesDirectories()
-        .addAppYaml("java11");
+    TestProject testProject =
+        new TestProject(testProjectDir.getRoot())
+            .addAppYamlBuildFileWithExtraFilesDirectories()
+            .addAppYaml("java11");
     Files.write(
         testProject.getProjectRoot().toPath().resolve("src/main/extras/test1.txt"),
         "hello".getBytes(Charsets.UTF_8));
@@ -142,5 +143,4 @@ public class StageAppYamlExtensionTest {
     BuildResult runWithNewFileAdded = testProject.applyGradleRunner("appengineStage");
     assertEquals(SUCCESS, runWithNewFileAdded.task(":appengineStage").getOutcome());
   }
-
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.gradle.appengine.appyaml;
 
 import com.google.cloud.tools.appengine.configuration.AppYamlProjectStageConfiguration;
+import com.google.cloud.tools.appengine.operations.AppYamlProjectStaging;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +56,7 @@ public class StageAppYamlExtensionTest {
   }
 
   @Test
-  public void testToStageArchiveConfiguration_allValuesSet() {
+  public void testToAppYamlProjectStageConfiguration_allValuesSet() {
     StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
 
     extension.setStagingDirectory(stagingDirectory);
@@ -63,7 +65,7 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     extension.setExtraFilesDirectories(extraFilesDirectories);
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
@@ -74,7 +76,7 @@ public class StageAppYamlExtensionTest {
   }
 
   @Test
-  public void testToStageArchiveConfiguration_nullExtraFiles() {
+  public void testToAppYamlProjectStageConfiguration_nullExtraFiles() {
     StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
 
     extension.setStagingDirectory(stagingDirectory);
@@ -83,7 +85,7 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     // extraFilesDirectories is not set (default = null)
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
@@ -92,7 +94,7 @@ public class StageAppYamlExtensionTest {
   }
 
   @Test
-  public void testToStageArchiveConfiguration_emptyExtraFiles() {
+  public void testToAppYamlProjectStageConfiguration_emptyExtraFiles() {
     StageAppYamlExtension extension = new StageAppYamlExtension(testContextProject);
 
     extension.setStagingDirectory(stagingDirectory);
@@ -101,11 +103,12 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     extension.setExtraFilesDirectories(Collections.emptyList());
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toStageArchiveConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
     Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
     Assert.assertEquals(0, generatedConfig.getExtraFilesDirectory().size());
   }
+
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
@@ -16,10 +16,6 @@
 
 package com.google.cloud.tools.gradle.appengine.appyaml;
 
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
-import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
-import static org.junit.Assert.assertEquals;
-
 import com.google.cloud.tools.appengine.configuration.AppYamlProjectStageConfiguration;
 import com.google.cloud.tools.gradle.appengine.TestProject;
 import com.google.common.base.Charsets;
@@ -33,6 +29,7 @@ import java.util.stream.Collectors;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,11 +70,11 @@ public class StageAppYamlExtensionTest {
 
     AppYamlProjectStageConfiguration generatedConfig =
         extension.toAppYamlProjectStageConfiguration();
-    assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
-    assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
-    assertEquals(artifact.toPath(), generatedConfig.getArtifact());
-    assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
-    assertEquals(
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertEquals(
         extraFilesDirectories.stream().map(File::toPath).collect(Collectors.toList()),
         generatedConfig.getExtraFilesDirectory());
   }
@@ -94,10 +91,10 @@ public class StageAppYamlExtensionTest {
 
     AppYamlProjectStageConfiguration generatedConfig =
         extension.toAppYamlProjectStageConfiguration();
-    assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
-    assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
-    assertEquals(artifact.toPath(), generatedConfig.getArtifact());
-    assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
     Assert.assertNull(generatedConfig.getExtraFilesDirectory());
   }
 
@@ -113,11 +110,11 @@ public class StageAppYamlExtensionTest {
 
     AppYamlProjectStageConfiguration generatedConfig =
         extension.toAppYamlProjectStageConfiguration();
-    assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
-    assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
-    assertEquals(artifact.toPath(), generatedConfig.getArtifact());
-    assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
-    assertEquals(0, generatedConfig.getExtraFilesDirectory().size());
+    Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
+    Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
+    Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
+    Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
+    Assert.assertEquals(0, generatedConfig.getExtraFilesDirectory().size());
   }
 
   @Test
@@ -131,16 +128,18 @@ public class StageAppYamlExtensionTest {
         "hello".getBytes(Charsets.UTF_8));
 
     BuildResult firstRun = testProject.applyGradleRunner("appengineStage");
-    assertEquals(SUCCESS, firstRun.task(":appengineStage").getOutcome());
+    Assert.assertEquals(TaskOutcome.SUCCESS, firstRun.task(":appengineStage").getOutcome());
 
     BuildResult secondRunNoChange = testProject.applyGradleRunner("appengineStage");
-    assertEquals(UP_TO_DATE, secondRunNoChange.task(":appengineStage").getOutcome());
+    Assert.assertEquals(
+        TaskOutcome.UP_TO_DATE, secondRunNoChange.task(":appengineStage").getOutcome());
 
     Files.write(
         testProject.getProjectRoot().toPath().resolve("src/main/extras/test2.txt"),
         "hello".getBytes(Charsets.UTF_8));
 
     BuildResult runWithNewFileAdded = testProject.applyGradleRunner("appengineStage");
-    assertEquals(SUCCESS, runWithNewFileAdded.task(":appengineStage").getOutcome());
+    Assert.assertEquals(
+        TaskOutcome.SUCCESS, runWithNewFileAdded.task(":appengineStage").getOutcome());
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtensionTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.gradle.appengine.appyaml;
 
 import com.google.cloud.tools.appengine.configuration.AppYamlProjectStageConfiguration;
-import com.google.cloud.tools.appengine.operations.AppYamlProjectStaging;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -25,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,7 +63,8 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     extension.setExtraFilesDirectories(extraFilesDirectories);
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig =
+        extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
@@ -85,7 +84,8 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     // extraFilesDirectories is not set (default = null)
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig =
+        extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
@@ -103,12 +103,12 @@ public class StageAppYamlExtensionTest {
     extension.setDockerDirectory(dockerDirectory);
     extension.setExtraFilesDirectories(Collections.emptyList());
 
-    AppYamlProjectStageConfiguration generatedConfig = extension.toAppYamlProjectStageConfiguration();
+    AppYamlProjectStageConfiguration generatedConfig =
+        extension.toAppYamlProjectStageConfiguration();
     Assert.assertEquals(appEngineDirectory.toPath(), generatedConfig.getAppEngineDirectory());
     Assert.assertEquals(stagingDirectory.toPath(), generatedConfig.getStagingDirectory());
     Assert.assertEquals(artifact.toPath(), generatedConfig.getArtifact());
     Assert.assertEquals(dockerDirectory.toPath(), generatedConfig.getDockerDirectory());
     Assert.assertEquals(0, generatedConfig.getExtraFilesDirectory().size());
   }
-
 }

--- a/src/test/resources/projects/AppEnginePluginTest/build-appyaml-extraFilesDirectories.gradle
+++ b/src/test/resources/projects/AppEnginePluginTest/build-appyaml-extraFilesDirectories.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id 'java'
+  id 'war'
+  id 'com.google.cloud.tools.appengine-appyaml'
+}
+
+appengine {
+  deploy {
+    projectId = "project"
+    version = "version"
+  }
+  stage {
+    extraFilesDirectories = "src/main/extras"
+  }
+}
+


### PR DESCRIPTION
Fixes #318.

- Input -> InputFiles on dockerFile for appengine-web.xml staging.
- InputFiles on extraFilesDirectory method renamed to an actual
  getter.
- Also renames the configuration generater to actual name.