### PR TITLE
Resolve GCLOUD_CONFIG/APPENGINE_CONFIG late

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
@@ -108,10 +108,7 @@ public class AppEngineAppYamlPlugin implements Plugin<Project> {
             deploy.setAppEngineDirectory(stageExtension.getAppEngineDirectory());
           }
 
-          AppYamlDeployTargetResolver resolver =
-              new AppYamlDeployTargetResolver(cloudSdkOperations.getGcloud());
-          deploy.setProjectId(resolver.getProject(deploy.getProjectId()));
-          deploy.setVersion(resolver.getVersion(deploy.getVersion()));
+          deploy.setDeployTargetResolver(new AppYamlDeployTargetResolver(cloudSdkOperations));
 
           DeployAllTask deployAllTask =
               (DeployAllTask)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolver.java
@@ -20,11 +20,12 @@ package com.google.cloud.tools.gradle.appengine.appyaml;
 import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.APPENGINE_CONFIG;
 import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.GCLOUD_CONFIG;
 
-import com.google.cloud.tools.appengine.operations.Gcloud;
+import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import com.google.cloud.tools.gradle.appengine.core.ConfigReader;
+import com.google.cloud.tools.gradle.appengine.core.DeployTargetResolver;
 import org.gradle.api.GradleException;
 
-public class AppYamlDeployTargetResolver {
+public class AppYamlDeployTargetResolver implements DeployTargetResolver {
 
   static final String PROJECT_ERROR =
       "Deployment projectId must be defined or configured to read from system state\n"
@@ -46,10 +47,10 @@ public class AppYamlDeployTargetResolver {
           + APPENGINE_CONFIG
           + " is not allowed for app.yaml based projects";
 
-  private final Gcloud gcloud;
+  private final CloudSdkOperations cloudSdkOperations;
 
-  public AppYamlDeployTargetResolver(Gcloud gcloud) {
-    this.gcloud = gcloud;
+  public AppYamlDeployTargetResolver(CloudSdkOperations cloudSdkOperations) {
+    this.cloudSdkOperations = cloudSdkOperations;
   }
 
   /**
@@ -57,13 +58,14 @@ public class AppYamlDeployTargetResolver {
    * allowed for app.yaml based projects), show usage. If set to GCLOUD_CONFIG then read from
    * gcloud's global state. If set but not a keyword then just return the set value.
    */
+  @Override
   public String getProject(String configString) {
     if (configString == null
         || configString.trim().isEmpty()
         || configString.equals(APPENGINE_CONFIG)) {
       throw new GradleException(PROJECT_ERROR);
     } else if (configString.equals(GCLOUD_CONFIG)) {
-      return ConfigReader.getProject(gcloud);
+      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
     } else {
       return configString;
     }
@@ -74,6 +76,7 @@ public class AppYamlDeployTargetResolver {
    * allowed for app.yaml based deployments), show usage. If set to GCLOUD_CONFIG then allow gcloud
    * to generate a version. If set but not a keyword then just return the set value.
    */
+  @Override
   public String getVersion(String configString) {
     if (configString == null
         || configString.trim().isEmpty()

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolver.java
@@ -64,11 +64,11 @@ public class AppYamlDeployTargetResolver implements DeployTargetResolver {
         || configString.trim().isEmpty()
         || configString.equals(APPENGINE_CONFIG)) {
       throw new GradleException(PROJECT_ERROR);
-    } else if (configString.equals(GCLOUD_CONFIG)) {
-      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
-    } else {
-      return configString;
     }
+    if (configString.equals(GCLOUD_CONFIG)) {
+      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
+    }
+    return configString;
   }
 
   /**
@@ -82,11 +82,11 @@ public class AppYamlDeployTargetResolver implements DeployTargetResolver {
         || configString.trim().isEmpty()
         || configString.equals(APPENGINE_CONFIG)) {
       throw new GradleException(VERSION_ERROR);
-    } else if (configString.equals(GCLOUD_CONFIG)) {
+    }
+    if (configString.equals(GCLOUD_CONFIG)) {
       // can be null to allow gcloud to generate this
       return null;
-    } else {
-      return configString;
     }
+    return configString;
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployExtension.java
@@ -53,7 +53,7 @@ public class DeployExtension {
 
   DeployConfiguration toDeployConfiguration(List<Path> deployables) {
     String processedProjectId = deployTargetResolver.getProject(projectId);
-    String processedVersion = deployTargetResolver.getProject(version);
+    String processedVersion = deployTargetResolver.getVersion(version);
     return DeployConfiguration.builder(deployables)
         .bucket(bucket)
         .imageUrl(imageUrl)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployExtension.java
@@ -28,6 +28,8 @@ import org.gradle.api.Project;
 /** Extension element to define Deployable configurations for App Engine. */
 public class DeployExtension {
 
+  @InternalProperty private DeployTargetResolver deployTargetResolver;
+
   // named gradleProject to disambiguate with deploy parameter "project"
   private final Project gradleProject;
 
@@ -45,21 +47,28 @@ public class DeployExtension {
     this.gradleProject = gradleProject;
   }
 
+  public void setDeployTargetResolver(DeployTargetResolver deployTargetResolver) {
+    this.deployTargetResolver = deployTargetResolver;
+  }
+
   DeployConfiguration toDeployConfiguration(List<Path> deployables) {
+    String processedProjectId = deployTargetResolver.getProject(projectId);
+    String processedVersion = deployTargetResolver.getProject(version);
     return DeployConfiguration.builder(deployables)
         .bucket(bucket)
         .imageUrl(imageUrl)
-        .projectId(projectId)
+        .projectId(processedProjectId)
         .promote(promote)
         .server(server)
         .stopPreviousVersion(stopPreviousVersion)
-        .version(version)
+        .version(processedVersion)
         .build();
   }
 
   DeployProjectConfigurationConfiguration toDeployProjectConfigurationConfiguration() {
+    String processedProjectId = deployTargetResolver.getProject(projectId);
     return DeployProjectConfigurationConfiguration.builder(appEngineDirectory.toPath())
-        .projectId(projectId)
+        .projectId(processedProjectId)
         .server(server)
         .build();
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.gradle.appengine.core;
+
+/** Used for processing user configured project/version when generating config objects. */
+public interface DeployTargetResolver {
+  String getProject(String configString);
+
+  String getVersion(String configString);
+}

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfigura
 import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import com.google.cloud.tools.gradle.appengine.core.DeployAllTask;
 import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
+import com.google.cloud.tools.gradle.appengine.core.DeployTargetResolver;
 import com.google.cloud.tools.gradle.appengine.core.DeployTask;
 import com.google.cloud.tools.gradle.appengine.core.ToolsExtension;
 import com.google.common.base.Strings;
@@ -119,9 +120,10 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
                   .resolve("appengine-web.xml")
                   .toFile();
 
-          // configure the supplier for project/version parameters
-          deploy.setDeployTargetResolver(
-              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations));
+          // configure the resolver for projectId/version parameters
+          DeployTargetResolver standardResolver =
+              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
+          deploy.setDeployTargetResolver(standardResolver);
 
           DeployAllTask deployAllTask =
               (DeployAllTask)
@@ -138,12 +140,11 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
           deployTask.setAppYaml(stageExtension.getStagingDirectory().toPath().resolve("app.yaml"));
 
           // configure the runExtension's project parameter
-          // assign the run project to the deploy project if none is specified
+          // assign the run projectId to the deploy projectId if none is specified
           if (Strings.isNullOrEmpty(runExtension.getProjectId())) {
             runExtension.setProjectId(deploy.getProjectId());
           }
-          runExtension.setDeployTargetResolver(
-              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations));
+          runExtension.setDeployTargetResolver(standardResolver);
         });
   }
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -17,13 +17,9 @@
 
 package com.google.cloud.tools.gradle.appengine.standard;
 
-import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.APPENGINE_CONFIG;
-import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.GCLOUD_CONFIG;
-
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfiguration;
 import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
-import com.google.cloud.tools.gradle.appengine.core.ConfigReader;
 import com.google.cloud.tools.gradle.appengine.core.DeployAllTask;
 import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
 import com.google.cloud.tools.gradle.appengine.core.DeployTask;
@@ -123,11 +119,9 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
                   .resolve("appengine-web.xml")
                   .toFile();
 
-          // configure the deploy extensions's project/version parameters
-          StandardDeployTargetResolver resolver =
-              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations.getGcloud());
-          deploy.setProjectId(resolver.getProject(deploy.getProjectId()));
-          deploy.setVersion(resolver.getVersion(deploy.getVersion()));
+          // configure the supplier for project/version parameters
+          deploy.setDeployTargetResolver(
+              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations));
 
           DeployAllTask deployAllTask =
               (DeployAllTask)
@@ -148,11 +142,8 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
           if (Strings.isNullOrEmpty(runExtension.getProjectId())) {
             runExtension.setProjectId(deploy.getProjectId());
           }
-          if (runExtension.getProjectId().equals(GCLOUD_CONFIG)) {
-            runExtension.setProjectId(ConfigReader.getProject(cloudSdkOperations.getGcloud()));
-          } else if (runExtension.getProjectId().equals(APPENGINE_CONFIG)) {
-            runExtension.setProjectId(ConfigReader.getProject(appengineWebXml));
-          }
+          runExtension.setDeployTargetResolver(
+              new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations));
         });
   }
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -18,6 +18,8 @@
 package com.google.cloud.tools.gradle.appengine.standard;
 
 import com.google.cloud.tools.appengine.configuration.RunConfiguration;
+import com.google.cloud.tools.gradle.appengine.core.DeployTargetResolver;
+import com.google.cloud.tools.gradle.appengine.core.InternalProperty;
 import com.google.cloud.tools.gradle.appengine.util.NullSafe;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -31,6 +33,8 @@ import org.gradle.api.plugins.BasePlugin;
 
 /** Extension element to define Run configurations for App Engine Standard Environments. */
 public class RunExtension {
+
+  @InternalProperty private DeployTargetResolver deployTargetResolver;
 
   private final Project project;
   private int startSuccessTimeout;
@@ -71,6 +75,10 @@ public class RunExtension {
    */
   public RunExtension(Project project) {
     this.project = project;
+  }
+
+  public void setDeployTargetResolver(DeployTargetResolver deployTargetResolver) {
+    this.deployTargetResolver = deployTargetResolver;
   }
 
   public int getStartSuccessTimeout() {
@@ -339,6 +347,7 @@ public class RunExtension {
   }
 
   RunConfiguration toRunConfiguration() {
+    String processedProjectId = deployTargetResolver.getProject(projectId);
     return RunConfiguration.builder(
             services.stream().map(File::toPath).collect(Collectors.toList()))
         .additionalArguments(additionalArguments)
@@ -359,7 +368,7 @@ public class RunExtension {
         .logLevel(logLevel)
         .maxModuleInstances(maxModuleInstances)
         .port(port)
-        .projectId(projectId)
+        .projectId(processedProjectId)
         .pythonStartupArgs(pythonStartupArgs)
         .pythonStartupScript(pythonStartupScript)
         .runtime(runtime)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolver.java
@@ -20,12 +20,13 @@ package com.google.cloud.tools.gradle.appengine.standard;
 import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.APPENGINE_CONFIG;
 import static com.google.cloud.tools.gradle.appengine.core.ConfigReader.GCLOUD_CONFIG;
 
-import com.google.cloud.tools.appengine.operations.Gcloud;
+import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import com.google.cloud.tools.gradle.appengine.core.ConfigReader;
+import com.google.cloud.tools.gradle.appengine.core.DeployTargetResolver;
 import java.io.File;
 import org.gradle.api.GradleException;
 
-public class StandardDeployTargetResolver {
+public class StandardDeployTargetResolver implements DeployTargetResolver {
 
   static final String PROJECT_ERROR =
       "Deployment projectId must be defined or configured to read from system state\n"
@@ -48,11 +49,11 @@ public class StandardDeployTargetResolver {
           + "' to have gcloud generate a version for you.";
 
   private final File appengineWebXml;
-  private final Gcloud gcloud;
+  private final CloudSdkOperations cloudSdkOperations;
 
-  public StandardDeployTargetResolver(File appengineWebXml, Gcloud gcloud) {
+  public StandardDeployTargetResolver(File appengineWebXml, CloudSdkOperations cloudSdkOperations) {
     this.appengineWebXml = appengineWebXml;
-    this.gcloud = gcloud;
+    this.cloudSdkOperations = cloudSdkOperations;
   }
 
   /**
@@ -60,13 +61,14 @@ public class StandardDeployTargetResolver {
    * APPENGINE_CONFIG then read from appengine-web.xml. If set to GCLOUD_CONFIG then read from
    * gcloud's config state. If set but not a keyword then just return the set value.
    */
+  @Override
   public String getProject(String configString) {
     if (configString == null || configString.trim().isEmpty()) {
       throw new GradleException(PROJECT_ERROR);
     } else if (configString.equals(APPENGINE_CONFIG)) {
       return ConfigReader.getProject(appengineWebXml);
     } else if (configString.equals(GCLOUD_CONFIG)) {
-      return ConfigReader.getProject(gcloud);
+      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
     } else {
       return configString;
     }
@@ -77,6 +79,7 @@ public class StandardDeployTargetResolver {
    * APPENGINE_CONFIG then read from appengine-web.xml. If set to GCLOUD_CONFIG then allow gcloud to
    * generate a version. If set but not a keyword then just return the set value.
    */
+  @Override
   public String getVersion(String configString) {
     if (configString == null || configString.trim().isEmpty()) {
       throw new GradleException(VERSION_ERROR);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolver.java
@@ -65,13 +65,14 @@ public class StandardDeployTargetResolver implements DeployTargetResolver {
   public String getProject(String configString) {
     if (configString == null || configString.trim().isEmpty()) {
       throw new GradleException(PROJECT_ERROR);
-    } else if (configString.equals(APPENGINE_CONFIG)) {
-      return ConfigReader.getProject(appengineWebXml);
-    } else if (configString.equals(GCLOUD_CONFIG)) {
-      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
-    } else {
-      return configString;
     }
+    if (configString.equals(APPENGINE_CONFIG)) {
+      return ConfigReader.getProject(appengineWebXml);
+    }
+    if (configString.equals(GCLOUD_CONFIG)) {
+      return ConfigReader.getProject(cloudSdkOperations.getGcloud());
+    }
+    return configString;
   }
 
   /**
@@ -83,13 +84,14 @@ public class StandardDeployTargetResolver implements DeployTargetResolver {
   public String getVersion(String configString) {
     if (configString == null || configString.trim().isEmpty()) {
       throw new GradleException(VERSION_ERROR);
-    } else if (configString.equals(APPENGINE_CONFIG)) {
+    }
+    if (configString.equals(APPENGINE_CONFIG)) {
       return ConfigReader.getVersion(appengineWebXml);
-    } else if (configString.equals(GCLOUD_CONFIG)) {
+    }
+    if (configString.equals(GCLOUD_CONFIG)) {
       // can be null to allow gcloud to generate this
       return null;
-    } else {
-      return configString;
     }
+    return configString;
   }
 }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolverTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppYamlDeployTargetResolverTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkOutOfDateExc
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkVersionFileException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.process.ProcessHandlerException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.serialization.CloudSdkConfig;
+import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import com.google.cloud.tools.gradle.appengine.core.ConfigReader;
 import java.io.IOException;
 import org.gradle.api.GradleException;
@@ -42,26 +43,30 @@ public class AppYamlDeployTargetResolverTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Mock Gcloud gcloud;
+  @Mock CloudSdkOperations cloudSdkOperations;
   @Mock CloudSdkConfig cloudSdkConfig;
 
   @Before
   public void setup()
       throws CloudSdkNotFoundException, ProcessHandlerException, CloudSdkOutOfDateException,
           CloudSdkVersionFileException, IOException {
+    Mockito.when(cloudSdkOperations.getGcloud()).thenReturn(gcloud);
     Mockito.when(gcloud.getConfig()).thenReturn(cloudSdkConfig);
     Mockito.when(cloudSdkConfig.getProject()).thenReturn(PROJECT_GCLOUD);
   }
 
   @Test
   public void testGetProject_buildConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     String result = deployTargetResolver.getProject("some-project");
     Assert.assertEquals("some-project", result);
   }
 
   @Test
   public void testGetProject_appengineConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     try {
       deployTargetResolver.getProject(ConfigReader.APPENGINE_CONFIG);
       Assert.fail();
@@ -72,14 +77,16 @@ public class AppYamlDeployTargetResolverTest {
 
   @Test
   public void testGetProject_gcloudConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     String result = deployTargetResolver.getProject(ConfigReader.GCLOUD_CONFIG);
     Assert.assertEquals(PROJECT_GCLOUD, result);
   }
 
   @Test
   public void testGetProject_nothingSet() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     try {
       deployTargetResolver.getProject(null);
       Assert.fail();
@@ -90,14 +97,16 @@ public class AppYamlDeployTargetResolverTest {
 
   @Test
   public void testGetVersion_buildConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     String result = deployTargetResolver.getVersion("some-version");
     Assert.assertEquals("some-version", result);
   }
 
   @Test
   public void testGetVersion_appengineConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     try {
       deployTargetResolver.getVersion(ConfigReader.APPENGINE_CONFIG);
       Assert.fail();
@@ -108,14 +117,16 @@ public class AppYamlDeployTargetResolverTest {
 
   @Test
   public void testGetVersion_gcloudConfig() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     String result = deployTargetResolver.getVersion(ConfigReader.GCLOUD_CONFIG);
     Assert.assertNull(result);
   }
 
   @Test
   public void testGetVersion_nothingSet() {
-    AppYamlDeployTargetResolver deployTargetResolver = new AppYamlDeployTargetResolver(gcloud);
+    AppYamlDeployTargetResolver deployTargetResolver =
+        new AppYamlDeployTargetResolver(cloudSdkOperations);
     try {
       deployTargetResolver.getVersion(null);
       Assert.fail();

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTaskTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTaskTest.java
@@ -48,8 +48,9 @@ public class DeployAllTaskTest {
 
   @Mock private Gcloud gcloud;
   @Mock private Deployment deploy;
+  @Mock private DeployTargetResolver deployTargetResolver;
 
-  private DeployExtension deployConfig;
+  private DeployExtension deployExtension;
   private ArgumentCaptor<DeployConfiguration> deployCapture;
 
   private DeployAllTask deployAllTask;
@@ -60,12 +61,13 @@ public class DeployAllTaskTest {
   @Before
   public void setup() throws IOException {
     Project tempProject = ProjectBuilder.builder().build();
-    deployConfig = new DeployExtension(tempProject);
+    deployExtension = new DeployExtension(tempProject);
+    deployExtension.setDeployTargetResolver(deployTargetResolver);
     deployCapture = ArgumentCaptor.forClass(DeployConfiguration.class);
     stageDir = tempFolder.newFolder("staging");
 
     deployAllTask = tempProject.getTasks().create("tempDeployAllTask", DeployAllTask.class);
-    deployAllTask.setDeployExtension(deployConfig);
+    deployAllTask.setDeployExtension(deployExtension);
     deployAllTask.setGcloud(gcloud);
     deployAllTask.setStageDirectory(stageDir);
 
@@ -74,7 +76,7 @@ public class DeployAllTaskTest {
 
   @Test
   public void testDeployAllAction_standard() throws AppEngineException, IOException {
-    deployConfig.setAppEngineDirectory(stageDir);
+    deployExtension.setAppEngineDirectory(stageDir);
 
     final Path appYaml = tempFolder.newFile("staging/app.yaml").toPath();
     final Path cronYaml = tempFolder.newFile("staging/cron.yaml").toPath();
@@ -99,7 +101,7 @@ public class DeployAllTaskTest {
 
   @Test
   public void testDeployAllAction_appyaml() throws AppEngineException, IOException {
-    deployConfig.setAppEngineDirectory(tempFolder.newFolder("appengine"));
+    deployExtension.setAppEngineDirectory(tempFolder.newFolder("appengine"));
 
     final Path appYaml = tempFolder.newFile("staging/app.yaml").toPath();
     final Path cronYaml = tempFolder.newFile("appengine/cron.yaml").toPath();
@@ -125,7 +127,7 @@ public class DeployAllTaskTest {
   @Test
   public void testDeployAllAction_validFileNotInDirStandard()
       throws AppEngineException, IOException {
-    deployConfig.setAppEngineDirectory(stageDir);
+    deployExtension.setAppEngineDirectory(stageDir);
 
     final Path appYaml = tempFolder.newFile("staging/app.yaml").toPath();
     final Path validInDifferentDirYaml = tempFolder.newFile("queue.yaml").toPath();
@@ -141,7 +143,7 @@ public class DeployAllTaskTest {
   @Test
   public void testDeployAllAction_validFileNotInDirAppYaml()
       throws AppEngineException, IOException {
-    deployConfig.setAppEngineDirectory(tempFolder.newFolder("appengine"));
+    deployExtension.setAppEngineDirectory(tempFolder.newFolder("appengine"));
 
     // Make YAMLS
     final Path appYaml = tempFolder.newFile("staging/app.yaml").toPath();

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployExtensionTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/DeployExtensionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.gradle.appengine.core;
+
+import com.google.cloud.tools.appengine.configuration.DeployConfiguration;
+import com.google.common.collect.ImmutableList;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeployExtensionTest {
+
+  @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+  @Mock private DeployTargetResolver deployTargetResolver;
+  private Project testProject;
+
+  @Before
+  public void setUp() {
+    Mockito.when(deployTargetResolver.getProject("test-project-id"))
+        .thenReturn("processed-project-id");
+    Mockito.when(deployTargetResolver.getVersion("test-version")).thenReturn("processed-version");
+    testProject = ProjectBuilder.builder().withProjectDir(testProjectDir.getRoot()).build();
+  }
+
+  @Test
+  public void testToDeployConfiguration_allValuesSet() {
+    DeployExtension testExtension = new DeployExtension(testProject);
+    testExtension.setDeployTargetResolver(deployTargetResolver);
+
+    testExtension.setBucket("test-bucket");
+    testExtension.setImageUrl("test-img-url");
+    testExtension.setProjectId("test-project-id");
+    testExtension.setPromote(true);
+    testExtension.setServer("test-server");
+    testExtension.setStopPreviousVersion(true);
+    testExtension.setVersion("test-version");
+
+    List<Path> projects = ImmutableList.of(Paths.get("project1"), Paths.get("project2"));
+    DeployConfiguration x = testExtension.toDeployConfiguration(projects);
+
+    Assert.assertEquals(projects, x.getDeployables());
+    Assert.assertEquals("test-bucket", x.getBucket());
+    Assert.assertEquals("test-img-url", x.getImageUrl());
+    Assert.assertEquals("processed-project-id", x.getProjectId());
+    Assert.assertEquals(Boolean.TRUE, x.getPromote());
+    Assert.assertEquals("test-server", x.getServer());
+    Assert.assertEquals(Boolean.TRUE, x.getStopPreviousVersion());
+    Assert.assertEquals("processed-version", x.getVersion());
+
+    Mockito.verify(deployTargetResolver).getProject("test-project-id");
+    Mockito.verify(deployTargetResolver).getVersion("test-version");
+    Mockito.verifyNoMoreInteractions(deployTargetResolver);
+  }
+
+  @Test
+  public void testToDeployConfiguration_onlyRequiredValuesSet() {
+    DeployExtension testExtension = new DeployExtension(testProject);
+    testExtension.setDeployTargetResolver(deployTargetResolver);
+
+    testExtension.setProjectId("test-project-id");
+    testExtension.setVersion("test-version");
+
+    List<Path> projects = ImmutableList.of(Paths.get("project1"), Paths.get("project2"));
+    DeployConfiguration x = testExtension.toDeployConfiguration(projects);
+
+    Assert.assertEquals("processed-project-id", x.getProjectId());
+    Assert.assertEquals("processed-version", x.getVersion());
+
+    Assert.assertNull(x.getBucket());
+    Assert.assertNull(x.getImageUrl());
+    Assert.assertNull(x.getPromote());
+    Assert.assertNull(x.getServer());
+    Assert.assertNull(x.getStopPreviousVersion());
+
+    Mockito.verify(deployTargetResolver).getProject("test-project-id");
+    Mockito.verify(deployTargetResolver).getVersion("test-version");
+    Mockito.verifyNoMoreInteractions(deployTargetResolver);
+  }
+}

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkOutOfDateExc
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkVersionFileException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.process.ProcessHandlerException;
 import com.google.cloud.tools.appengine.operations.cloudsdk.serialization.CloudSdkConfig;
+import com.google.cloud.tools.gradle.appengine.core.CloudSdkOperations;
 import com.google.cloud.tools.gradle.appengine.core.ConfigReader;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
@@ -49,6 +50,7 @@ public class StandardDeployTargetResolverTest {
   private File appengineWebXml;
 
   @Mock Gcloud gcloud;
+  @Mock CloudSdkOperations cloudSdkOperations;
   @Mock CloudSdkConfig cloudSdkConfig;
 
   /** Setup PropertyResolverTest. */
@@ -57,6 +59,7 @@ public class StandardDeployTargetResolverTest {
       throws IOException, CloudSdkNotFoundException, ProcessHandlerException,
           CloudSdkOutOfDateException, CloudSdkVersionFileException {
     appengineWebXml = new File(temporaryFolder.newFolder("source", "WEB-INF"), "appengine-web.xml");
+    Mockito.when(cloudSdkOperations.getGcloud()).thenReturn(gcloud);
     Mockito.when(gcloud.getConfig()).thenReturn(cloudSdkConfig);
     Mockito.when(cloudSdkConfig.getProject()).thenReturn(PROJECT_GCLOUD);
 
@@ -74,7 +77,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetProject_buildConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getProject("some-project");
     Assert.assertEquals("some-project", result);
   }
@@ -82,7 +85,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetProject_appengineConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getProject(ConfigReader.APPENGINE_CONFIG);
     Assert.assertEquals(PROJECT_XML, result);
   }
@@ -90,7 +93,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetProject_gcloudConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getProject(ConfigReader.GCLOUD_CONFIG);
     Assert.assertEquals(PROJECT_GCLOUD, result);
   }
@@ -98,7 +101,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetProject_nothingSet() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     try {
       deployTargetResolver.getProject(null);
       Assert.fail();
@@ -110,7 +113,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetVersion_buildConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getVersion("some-version");
     Assert.assertEquals("some-version", result);
   }
@@ -118,7 +121,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetVersion_appengineConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getVersion(ConfigReader.APPENGINE_CONFIG);
     Assert.assertEquals(VERSION_XML, result);
   }
@@ -126,7 +129,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetVersion_gcloudConfig() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     String result = deployTargetResolver.getVersion(ConfigReader.GCLOUD_CONFIG);
     Assert.assertNull(result);
   }
@@ -134,7 +137,7 @@ public class StandardDeployTargetResolverTest {
   @Test
   public void testGetVersion_nothingSet() {
     StandardDeployTargetResolver deployTargetResolver =
-        new StandardDeployTargetResolver(appengineWebXml, gcloud);
+        new StandardDeployTargetResolver(appengineWebXml, cloudSdkOperations);
     try {
       deployTargetResolver.getVersion(null);
       Assert.fail();

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/StandardDeployTargetResolverTest.java
@@ -49,9 +49,9 @@ public class StandardDeployTargetResolverTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private File appengineWebXml;
 
-  @Mock Gcloud gcloud;
-  @Mock CloudSdkOperations cloudSdkOperations;
-  @Mock CloudSdkConfig cloudSdkConfig;
+  @Mock private Gcloud gcloud;
+  @Mock private CloudSdkOperations cloudSdkOperations;
+  @Mock private CloudSdkConfig cloudSdkConfig;
 
   /** Setup PropertyResolverTest. */
   @Before


### PR DESCRIPTION
If a user doesn't have the cloud sdk installed yet, but uses
GCLOUD_CONFIG, it results in a cloud sdk not found error.

While this seems like a strange case, it's safest for us
to only even attempt anything after we can guarantee the cloud
sdk is setup.