### PR TITLE
Add verbosity option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Added
+* `appengine.tools.verbosity` option for defining gcloud log verbosity ([#384](../../pull/384))
+
 ## 2.3.0
 ### Added
 * Update to appengine-plugins-core 0.9.0 ([#377](../../pull/377))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -97,6 +97,7 @@ The `tools` configuration has the following parameters :
 | `serviceAccountKeyFile` | A Google project service account key file to run Cloud SDK operations requiring an authenticated user. |
 | `cloudSdkHome`          | Location of the Cloud SDK. |
 | `cloudSdkVersion`       | The desired version of the Cloud SDK (e.g. "192.0.0"). |
+| `verbosity`             | The verbosity level for logging when gcloud is run. See [gcloud docs](https://cloud.google.com/sdk/gcloud/reference#--verbosity) for allowed values. |
 
 The Cloud SDK will be installed/updated/verified depending on which parameters are configured:
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ group = 'com.google.cloud.tools'
 dependencies {
   compile localGroovy()
   compile gradleApi()
-  compile 'com.google.cloud.tools:appengine-plugins-core:0.9.0'
+  compile 'com.google.cloud.tools:appengine-plugins-core:0.9.1'
 
   testCompile 'commons-io:commons-io:2.4'
   testCompile 'junit:junit:4.12'

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
@@ -80,7 +80,7 @@ public class AppEngineAppYamlPlugin implements Plugin<Project> {
         project -> {
           // create the sdk builder factory after we know the location of the sdk
           try {
-            new CloudSdkOperations(tools.getCloudSdkHome(), null);
+            new CloudSdkOperations(tools.getCloudSdkHome(), null, tools.getVerbosity());
           } catch (CloudSdkNotFoundException ex) {
             // this should be caught in AppEngineCorePluginConfig before it can ever reach here.
             throw new GradleException("Could not find CloudSDK: ", ex);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -107,7 +107,9 @@ public class AppEngineCorePluginConfiguration {
           try {
             cloudSdkOperations =
                 new CloudSdkOperations(
-                    toolsExtension.getCloudSdkHome(), toolsExtension.getServiceAccountKeyFile());
+                    toolsExtension.getCloudSdkHome(),
+                    toolsExtension.getServiceAccountKeyFile(),
+                    toolsExtension.getVerbosity());
           } catch (CloudSdkNotFoundException ex) {
             // this should never happen, not found exception only occurs when auto-discovery fails,
             // but we don't use that mechanism anymore.

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
@@ -42,7 +42,7 @@ public class CloudSdkOperations {
    * @param credentialFile optional path to a credential file
    * @throws CloudSdkNotFoundException when cloud sdk path cannot be validated
    */
-  public CloudSdkOperations(File cloudSdkHome, File credentialFile)
+  public CloudSdkOperations(File cloudSdkHome, File credentialFile, String verbosity)
       throws CloudSdkNotFoundException {
     cloudSdk = new CloudSdk.Builder().sdkPath(cloudSdkHome.toPath()).build();
     gcloud =
@@ -51,6 +51,7 @@ public class CloudSdkOperations {
             .setMetricsEnvironment(
                 getClass().getPackage().getImplementationTitle(),
                 getClass().getPackage().getImplementationVersion())
+            .setVerbosity(verbosity)
             .build();
   }
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
@@ -40,6 +40,7 @@ public class CloudSdkOperations {
    *
    * @param cloudSdkHome path to cloud sdk
    * @param credentialFile optional path to a credential file
+   * @param verbosity logging verbosity level for gcloud commands
    * @throws CloudSdkNotFoundException when cloud sdk path cannot be validated
    */
   public CloudSdkOperations(File cloudSdkHome, File credentialFile, String verbosity)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ToolsExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ToolsExtension.java
@@ -28,6 +28,7 @@ public class ToolsExtension {
   private File cloudSdkHome;
   private String cloudSdkVersion;
   private File cloudSdkServiceAccountFile;
+  private String verbosity;
 
   public ToolsExtension(Project project) {
     this.project = project;
@@ -55,5 +56,13 @@ public class ToolsExtension {
 
   public void setServiceAccountKeyFile(Object cloudSdkServiceAccountFile) {
     this.cloudSdkServiceAccountFile = project.file(cloudSdkServiceAccountFile);
+  }
+
+  public String getVerbosity() {
+    return verbosity;
+  }
+
+  public void setVerbosity(String verbosity) {
+    this.verbosity = verbosity;
   }
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
@@ -65,7 +65,8 @@ public class SourceContextPlugin implements Plugin<Project> {
     project.afterEvaluate(
         project -> {
           try {
-            cloudSdkOperations = new CloudSdkOperations(tools.getCloudSdkHome(), null);
+            cloudSdkOperations =
+                new CloudSdkOperations(tools.getCloudSdkHome(), null, tools.getVerbosity());
           } catch (CloudSdkNotFoundException ex) {
             // this should be caught in AppEngineCorePluginConfig before it can ever reach here.
             throw new GradleException("Could not find CloudSDK: ", ex);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -97,7 +97,8 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
           // tools extension required to initialize cloudSdkOperations
           ToolsExtension tools = appengineExtension.getTools();
           try {
-            cloudSdkOperations = new CloudSdkOperations(tools.getCloudSdkHome(), null);
+            cloudSdkOperations =
+                new CloudSdkOperations(tools.getCloudSdkHome(), null, tools.getVerbosity());
           } catch (CloudSdkNotFoundException ex) {
             // this should be caught in AppEngineCorePluginConfig before it can ever reach here.
             throw new GradleException("Could not find CloudSDK: ", ex);


### PR DESCRIPTION
Verified manually that gcloud app deploy run from plugin respect verbosity flag
Can really find a good way to test this without reflection. I guess I could do that?