### PR TITLE
Allow configuration using the plugins block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Fixed
+* Fixed bug when using `plugins` block in `build.gradle` ([#388](../../pull/388))
+
 ## 2.4.0
 ### Added
 * `appengine.tools.verbosity` option for defining gcloud log verbosity ([#384](../../pull/384))

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -61,6 +61,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     this.project = project;
+    project.getPluginManager().apply(WarPlugin.class);
     appengineExtension =
         project.getExtensions().create("appengine", AppEngineStandardExtension.class);
     appengineExtension.createSubExtensions(project);


### PR DESCRIPTION
Must ensure `war` is applied before we work on our plugin. We could rewrite the whole plugin to configure on demand and use the necessary late evaluation mechanism but this is sufficient for now.