### PR TITLE
ci: workaround to use java 11 on kokoro macos

### DIFF
--- a/kokoro/continuous_mac.sh
+++ b/kokoro/continuous_mac.sh
@@ -8,6 +8,10 @@ set -x
 gcloud components update
 gcloud components install app-engine-java
 
+# use adoptopenjdk11 until Java 11 support is added to Kokoro MacOS environment
+brew install adoptopenjdk11
+JAVA_HOME=$(/usr/libexec/java_home -v11)
+
 cd github/app-gradle-plugin
 ./gradlew check
 # bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Kokoro MacOS migration from Mojave to Monterey has Java version 19 by default. This PR adds a workaround to run MacOS CI on Java 11. 