### PR TITLE
Fix deprecation warnings in build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,14 +41,14 @@ java {
 group = "com.google.cloud.tools"
 
 dependencies {
-  compile(localGroovy())
-  compile(gradleApi())
-  compile("com.google.cloud.tools:appengine-plugins-core:0.9.9")
+  implementation(localGroovy())
+  implementation(gradleApi())
+  api("com.google.cloud.tools:appengine-plugins-core:0.9.9")
 
-  testCompile("commons-io:commons-io:2.4")
-  testCompile("junit:junit:4.12")
-  testCompile("org.hamcrest:hamcrest-library:1.3")
-  testCompile("org.mockito:mockito-core:2.23.4")
+  testImplementation("commons-io:commons-io:2.4")
+  testImplementation("junit:junit:4.12")
+  testImplementation("org.hamcrest:hamcrest-library:1.3")
+  testImplementation("org.mockito:mockito-core:2.23.4")
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,12 @@ tasks.jar.configure {
   }
 }
 
+tasks.withType<JavaCompile>().configureEach { 
+    options.compilerArgs = options.compilerArgs + listOf(
+      "-Xlint:all"
+    )
+}
+
 /* TESTING */
 tasks.test.configure {
   testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
   id("maven")
   id("java-gradle-plugin")
   id("net.researchgate.release") version "2.6.0"
-  id("com.github.sherter.google-java-format") version "0.8"
+  id("com.github.sherter.google-java-format") version "0.9"
   id("checkstyle")
   id("jacoco")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,13 +102,13 @@ tasks.register<Test>("integTest") {
 /* RELEASING */
 tasks.register<Jar>("sourceJar") {
   from(sourceSets.main.get().allJava)
-  classifier = "sources"
+  archiveClassifier.set("sources")
 }
 
 tasks.register<Jar>("javadocJar") {
   dependsOn(tasks.javadoc)
   from(tasks.javadoc.map { it.destinationDir!! })
-  classifier = "javadoc"
+  archiveClassifier.set("javadoc")
 }
 
 project.afterEvaluate {
@@ -191,7 +191,7 @@ tasks.check.configure {
 checkstyle {
   toolVersion = "8.18"
   // get the google_checks.xml file from the actual tool we"re invoking)
-  config = resources.text.fromArchiveEntry(configurations.checkstyle.files.first(), "google_checks.xml")
+  config = resources.text.fromArchiveEntry(configurations.checkstyle.get().files.first(), "google_checks.xml")
   maxErrors = 0
   maxWarnings = 0
   tasks.checkstyleTest.configure {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -107,8 +107,10 @@ public class StageAppYamlExtension {
   }
 
   AppYamlProjectStageConfiguration toAppYamlProjectStageConfiguration() {
-    return AppYamlProjectStageConfiguration.builder(
-            appEngineDirectory.toPath(), artifact.toPath(), stagingDirectory.toPath())
+    return AppYamlProjectStageConfiguration.builder()
+        .appEngineDirectory(appEngineDirectory.toPath())
+        .artifact(artifact.toPath())
+        .stagingDirectory(stagingDirectory.toPath())
         .dockerDirectory(NullSafe.convert(dockerDirectory, File::toPath))
         .extraFilesDirectories(NullSafe.convert(extraFilesDirectories, File::toPath))
         .build();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
@@ -169,8 +169,9 @@ public class StageStandardExtension {
   }
 
   AppEngineWebXmlProjectStageConfiguration toStageStandardConfiguration() {
-    return AppEngineWebXmlProjectStageConfiguration.builder(
-            sourceDirectory.toPath(), stagingDirectory.toPath())
+    return AppEngineWebXmlProjectStageConfiguration.builder()
+        .sourceDirectory(sourceDirectory.toPath())
+        .stagingDirectory(stagingDirectory.toPath())
         .compileEncoding(compileEncoding)
         .deleteJsps(deleteJsps)
         .disableJarJsps(disableJarJsps)


### PR DESCRIPTION
See individual commit messages for details.

The only deprecation warnings that remain are from https://github.com/GoogleCloudPlatform/app-gradle-plugin/pull/398 and #446, so those are not in scope here.