### PR TITLE
Bump testing libraries to their latest possible versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,12 +192,7 @@ googleJavaFormat {
 tasks.check.configure {
   dependsOn(tasks.verifyGoogleJavaFormat)
 }
-tasks.checkstyleMain.configure {
-  // Set up a soft dependency so that verifyGoogleFormat suggests running googleJavaFormat,
-  // before devs start fixing individual checkstyle violations manually.
-  shouldRunAfter(tasks.verifyGoogleJavaFormat)
-}
-tasks.named("checkstyleIntegTest").configure {
+tasks.withType<Checkstyle>().configureEach {
   // Set up a soft dependency so that verifyGoogleFormat suggests running googleJavaFormat,
   // before devs start fixing individual checkstyle violations manually.
   shouldRunAfter(tasks.verifyGoogleJavaFormat)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,8 +189,8 @@ tasks.check.configure {
 // to auto-format run ./gradlew googleJavaFormat
 
 checkstyle {
-  toolVersion = "8.18"
-  // get the google_checks.xml file from the actual tool we"re invoking)
+  toolVersion = "8.37"
+  // Get the google_checks.xml file from the actual tool we're invoking.
   config = resources.text.fromArchiveEntry(configurations.checkstyle.files.first(), "google_checks.xml")
   maxErrors = 0
   maxWarnings = 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
   compile(gradleApi())
   compile("com.google.cloud.tools:appengine-plugins-core:0.9.9")
 
-  testCompile("commons-io:commons-io:2.4")
+  testCompile("commons-io:commons-io:2.11.0")
   testCompile("junit:junit:4.12")
   testCompile("org.hamcrest:hamcrest-library:1.3")
   testCompile("org.mockito:mockito-core:2.23.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
   compile("com.google.cloud.tools:appengine-plugins-core:0.9.9")
 
   testCompile("commons-io:commons-io:2.11.0")
-  testCompile("junit:junit:4.12")
-  testCompile("org.hamcrest:hamcrest-library:1.3")
+  testCompile("junit:junit:4.13.2")
+  testCompile("org.hamcrest:hamcrest-library:2.2")
   testCompile("org.mockito:mockito-core:4.11.0")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
   testCompile("commons-io:commons-io:2.11.0")
   testCompile("junit:junit:4.12")
   testCompile("org.hamcrest:hamcrest-library:1.3")
-  testCompile("org.mockito:mockito-core:2.23.4")
+  testCompile("org.mockito:mockito-core:4.11.0")
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,6 +186,16 @@ googleJavaFormat {
 tasks.check.configure {
   dependsOn(tasks.verifyGoogleJavaFormat)
 }
+tasks.checkstyleMain.configure {
+  // Set up a soft dependency so that verifyGoogleFormat suggests running googleJavaFormat,
+  // before devs start fixing individual checkstyle violations manually.
+  shouldRunAfter(tasks.verifyGoogleJavaFormat)
+}
+tasks.named("checkstyleIntegTest").configure {
+  // Set up a soft dependency so that verifyGoogleFormat suggests running googleJavaFormat,
+  // before devs start fixing individual checkstyle violations manually.
+  shouldRunAfter(tasks.verifyGoogleJavaFormat)
+}
 // to auto-format run ./gradlew googleJavaFormat
 
 checkstyle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,7 +212,7 @@ checkstyle {
 
 /* TEST COVERAGE */
 jacoco {
-  toolVersion = "0.8.6"
+  toolVersion = "0.8.8"
 }
 
 tasks.jacocoTestReport {

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineAppYamlPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineAppYamlPluginIntegrationTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,7 +63,7 @@ public class AppEngineAppYamlPluginIntegrationTest {
             .withArguments("appengineDeploy")
             .build();
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Deployed service [appyaml-project]"));
 
     deleteProject();
@@ -81,18 +81,18 @@ public class AppEngineAppYamlPluginIntegrationTest {
             .withArguments("appengineDeployAll")
             .build();
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Deployed service [appyaml-project]"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Custom routings have been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("DoS protection has been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(),
         CoreMatchers.containsString("Indexes are being rebuilt. This may take a moment."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Cron jobs have been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Task queues have been updated."));
 
     deleteProject();

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.managedcloudsdk.ManagedCloudSdk;
 import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
@@ -131,7 +132,8 @@ public class AppEngineStandardPluginIntegrationTest {
 
     Assert.assertEquals(1, expectedLogFileDir.listFiles().length);
     File devAppserverLogFile = new File(expectedLogFileDir, "dev_appserver.out");
-    String devAppServerOutput = FileUtils.readFileToString(devAppserverLogFile);
+    String devAppServerOutput =
+        FileUtils.readFileToString(devAppserverLogFile, Charset.defaultCharset());
     Assert.assertTrue(devAppServerOutput.contains(devAppServerStartedString));
 
     AssertConnection.assertResponse(

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AppEngineStandardPluginIntegrationTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,7 +160,7 @@ public class AppEngineStandardPluginIntegrationTest {
             .withArguments("appengineDeploy", "--stacktrace")
             .build();
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(),
         CoreMatchers.containsString("Deployed service [standard-project]"));
 
@@ -177,19 +178,19 @@ public class AppEngineStandardPluginIntegrationTest {
             .withArguments("appengineDeployAll")
             .build();
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(),
         CoreMatchers.containsString("Deployed service [standard-project]"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Custom routings have been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("DoS protection has been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(),
         CoreMatchers.containsString("Indexes are being rebuilt. This may take a moment."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Cron jobs have been updated."));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Task queues have been updated."));
 
     deleteProject();

--- a/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
+++ b/src/integTest/java/com/google/cloud/tools/gradle/appengine/AssertConnection.java
@@ -24,6 +24,7 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 
 /** Assertions for checking connections web apps. */
@@ -36,7 +37,7 @@ public class AssertConnection {
       int responseCode = urlConnection.getResponseCode();
       Assert.assertEquals(expectedCode, responseCode);
       String response = CharStreams.toString(new InputStreamReader(urlConnection.getInputStream()));
-      Assert.assertThat(response, CoreMatchers.equalTo(expectedText));
+      MatcherAssert.assertThat(response, CoreMatchers.equalTo(expectedText));
     } catch (IOException e) {
       Assert.fail("IOException while running test");
     }
@@ -73,7 +74,7 @@ public class AssertConnection {
 
         // Will only reach this point when a response is reached
         Assert.assertEquals(expectedCode, responseCode);
-        Assert.assertThat(response, CoreMatchers.equalTo(expectedText));
+        MatcherAssert.assertThat(response, CoreMatchers.equalTo(expectedText));
         return;
 
       } catch (IOException ex) {

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
@@ -19,8 +19,8 @@ package com.google.cloud.tools.gradle.appengine;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -18,9 +18,9 @@
 package com.google.cloud.tools.gradle.appengine.appyaml;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfigurationTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfigurationTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.managedcloudsdk.components.SdkComponent;
 import java.io.IOException;
 import java.util.List;
 import org.gradle.api.Project;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -44,7 +45,7 @@ public class AppEngineCorePluginConfigurationTest {
                 .getTasks()
                 .getByPath(AppEngineCorePluginConfiguration.DOWNLOAD_CLOUD_SDK_TASK_NAME);
     List<SdkComponent> components = task.getComponents();
-    Assert.assertThat(components, Matchers.hasItem(SdkComponent.APP_ENGINE_JAVA));
+    MatcherAssert.assertThat(components, Matchers.hasItem(SdkComponent.APP_ENGINE_JAVA));
     Assert.assertEquals(1, components.size());
   }
 

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -18,9 +18,9 @@
 package com.google.cloud.tools.gradle.appengine.standard;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.BuildResultFilter;


### PR DESCRIPTION
See individual commits for details, copied here for convenience:

---

- Dependency version bumps:
  - Bump commons-io from 2.4 to 2.11.0
    * Replace usage of deprecated `readFileToString(File)` with `readFileToString(File, Charset)`
  - Bump junit from 4.12 to 4.13
    * Replace usages of deprecated `junit.Assert.assertThat` with `hamcrest.MatcherAssert.assertThat`
  - Bump hamcrest-library from 1.3 to 2.2
  - Bump mockito-core from 2.11.0 to 4.11.0
    * [Mockito 5.0](https://github.com/mockito/mockito/releases/tag/v5.0.0) (released at the same weeks as I raised the PR) requires Java 11 bytecode, so it's not viable yet, because CI runs on [8,11].
  - Bump jacoco from 0.8.6 to 0.8.8
  - Bump checkstyle from 8.18 to 8.37
    * 8.38 requires fixing 12 MissingJavadocType failures on public main source set classes.
    * 9.3 can be used once 8.38 javadocs are fixed, because that's the latest version that supports Java 8. 
    * Done up to here in https://github.com/GoogleCloudPlatform/app-gradle-plugin/pull/452
    * 10.x requires Java 11 in Gradle runtime, while the .github/workflows/unit-tests.yaml is executed on Java 8, Checkstyle 10+ is not viable.
- Have `verifyGoogleFormat` task run before checkstyle tasks (to suggest fixing via `./gradlew googleJavaFormat`)