### PR TITLE
Fix #446: replace deprecated archivePath with archiveFile in a backwards compatible way

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,12 +71,6 @@ tasks.jar.configure {
   }
 }
 
-tasks.withType<JavaCompile>().configureEach { 
-    options.compilerArgs = options.compilerArgs + listOf(
-      "-Xlint:all"
-    )
-}
-
 /* TESTING */
 tasks.test.configure {
   testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,12 @@ tasks.jar.configure {
   }
 }
 
+tasks.withType<JavaCompile>().configureEach { 
+    options.compilerArgs = options.compilerArgs + listOf(
+      "-Xlint:all"
+    )
+}
+
 /* TESTING */
 tasks.test.configure {
   testLogging {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
@@ -89,10 +89,10 @@ public class AppEngineAppYamlPlugin implements Plugin<Project> {
           // we can only set the default location of "archive" after project evaluation (callback)
           if (stageExtension.getArtifact() == null) {
             if (project.getPlugins().hasPlugin(WarPlugin.class)) {
-              War war = (War) project.getProperties().get("war");
+              War war = (War) project.getProperties().get(WarPlugin.WAR_TASK_NAME);
               stageExtension.setArtifact(war.getArchivePath());
             } else if (project.getPlugins().hasPlugin(JavaPlugin.class)) {
-              Jar jar = (Jar) project.getProperties().get("jar");
+              Jar jar = (Jar) project.getProperties().get(JavaPlugin.JAR_TASK_NAME);
               stageExtension.setArtifact(jar.getArchivePath());
             } else {
               throw new GradleException("Could not find JAR or WAR configuration");

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPlugin.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.gradle.appengine.core.DeployAllTask;
 import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
 import com.google.cloud.tools.gradle.appengine.core.DeployTask;
 import com.google.cloud.tools.gradle.appengine.core.ToolsExtension;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import java.io.File;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -90,10 +91,10 @@ public class AppEngineAppYamlPlugin implements Plugin<Project> {
           if (stageExtension.getArtifact() == null) {
             if (project.getPlugins().hasPlugin(WarPlugin.class)) {
               War war = (War) project.getProperties().get(WarPlugin.WAR_TASK_NAME);
-              stageExtension.setArtifact(war.getArchivePath());
+              stageExtension.setArtifact(GradleCompatibility.getArchiveFile(war));
             } else if (project.getPlugins().hasPlugin(JavaPlugin.class)) {
               Jar jar = (Jar) project.getProperties().get(JavaPlugin.JAR_TASK_NAME);
-              stageExtension.setArtifact(jar.getArchivePath());
+              stageExtension.setArtifact(GradleCompatibility.getArchiveFile(jar));
             } else {
               throw new GradleException("Could not find JAR or WAR configuration");
             }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/SourceContextPlugin.java
@@ -27,6 +27,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.War;
@@ -89,8 +91,10 @@ public class SourceContextPlugin implements Plugin<Project> {
                     genRepoInfoFile.setGcloud(cloudSdkOperations.getGcloud());
                   });
             });
-    configureArchiveTask(project.getTasks().withType(War.class).findByName("war"));
-    configureArchiveTask(project.getTasks().withType(Jar.class).findByName("jar"));
+    configureArchiveTask(
+        project.getTasks().withType(War.class).findByName(WarPlugin.WAR_TASK_NAME));
+    configureArchiveTask(
+        project.getTasks().withType(Jar.class).findByName(JavaPlugin.JAR_TASK_NAME));
   }
 
   // inject source-context into the META-INF directory of a jar or war

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
 import com.google.cloud.tools.gradle.appengine.core.DeployTargetResolver;
 import com.google.cloud.tools.gradle.appengine.core.DeployTask;
 import com.google.cloud.tools.gradle.appengine.core.ToolsExtension;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import com.google.common.base.Strings;
 import java.io.File;
 import org.gradle.api.GradleException;
@@ -149,7 +150,7 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
               project.afterEvaluate(
                   project -> {
                     War war = (War) project.getTasks().getByPath(WarPlugin.WAR_TASK_NAME);
-                    explodeWar.setWarFile(war.getArchivePath());
+                    explodeWar.setWarFile(GradleCompatibility.getArchiveFile(war));
                   });
             });
     project.getTasks().getByName(BasePlugin.ASSEMBLE_TASK_NAME).dependsOn(EXPLODE_WAR_TASK_NAME);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPlugin.java
@@ -147,10 +147,10 @@ public class AppEngineStandardPlugin implements Plugin<Project> {
               explodeWar.setDescription("Explode a war into a directory");
 
               project.afterEvaluate(
-                  project ->
-                      explodeWar.setWarFile(
-                          ((War) project.getTasks().getByPath(WarPlugin.WAR_TASK_NAME))
-                              .getArchivePath()));
+                  project -> {
+                    War war = (War) project.getTasks().getByPath(WarPlugin.WAR_TASK_NAME);
+                    explodeWar.setWarFile(war.getArchivePath());
+                  });
             });
     project.getTasks().getByName(BasePlugin.ASSEMBLE_TASK_NAME).dependsOn(EXPLODE_WAR_TASK_NAME);
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
@@ -1,0 +1,50 @@
+package com.google.cloud.tools.gradle.appengine.util;
+
+import java.io.File;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.util.GradleVersion;
+
+public class GradleCompatibility {
+
+  /**
+   * Compatibility method for getting the archive location.
+   *
+   * <p>Illustrious history of why deprecations should be handled as soon as they come up:
+   *
+   * <ul>
+   *   <li>Gradle 5.1.0-M1 added {@code getArchiveFile}: <a
+   *       href="https://github.com/gradle/gradle/commit/aff5155fc0f281e407df70dd1712cc5c08571f21#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR122">commit</a>
+   *   <li>Gradle 5.1.0-M1 deprecated {@code getArchivePath}: <a
+   *       href="https://github.com/gradle/gradle/commit/5c458c522af58612f2bfa85568e07aa29e585931#">commit</a>
+   *   <li>Gradle 6.0.0-RC1 added nagging to {@code getArchivePath}: <a
+   *       href="https://github.com/gradle/gradle/commit/e3824ff38513762a9a9ed554d7b2161e5be7c31a#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR148">commit</a>
+   *   <li>Gradle 6.0.0-RC1 removed nagging of {@code getArchivePath}, because Kotlin plugin wasn't
+   *       ready: <a
+   *       href="https://github.com/gradle/gradle/commit/f3cafc74853d0c4d0720b6a1b8bc70a09e12c6c1#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR149">commit</a>
+   *   <li>Gradle 7.1.0-RC1 re-enabled nagging of {@code getArchivePath} for Gradle 8: <a
+   *       href="https://github.com/gradle/gradle/commit/d17832e975a5718e95bf65e8d67a341f78732ff6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR156">commit</a>
+   *   <li>Gradle 7.1.0-RC1 removed nagging of {@code getArchivePath}, because Kotlin plugin wasn't
+   *       ready: <a
+   *       href="https://github.com/gradle/gradle/commit/3107f771a53e847cc5cd4f543e134d86e15215b6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR110">commit</a>
+   *   <li>Gradle 8.0-M2 removed {@code getArchivePath}: <a
+   *       href="https://github.com/gradle/gradle/commit/dbbd4d6875ae9faad57f5677810793f83ea22399#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdL156">commit</a>
+   *   <li>Gradle 8.0-M2 re-added {@code getArchivePath} with nagging for Gradle 9, because Kotlin
+   *       plugin wasn't ready: <a
+   *       href="https://github.com/gradle/gradle/commit/96abd3e04369a8869bca0658369ccb002bb6fe7e#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR154">commit</a>
+   * </ul>
+   *
+   * @param task the task whose archive location we're interested in.
+   * @return the archive location as a {@link File} for compatibility with older Gradle versions.
+   */
+  @SuppressWarnings("deprecation")
+  public static File getArchiveFile(AbstractArchiveTask task) {
+    if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("5.1")) >= 0) {
+      return task.getArchiveFile().get().getAsFile();
+    } else {
+      // Note: in case this fails to compile, because Gradle have succeeded with the removal, this
+      // needs to be replaced with a reflective call to getArchivePath()
+      // or the minimum Gradle version for GCP Gradle Plugin bumped up to 5.1+.
+      return task.getArchivePath();
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
@@ -14,40 +14,28 @@ public class GradleCompatibility {
   /**
    * Compatibility method for getting the archive location.
    *
-   * <p>Illustrious history of why deprecations should be handled as soon as they come up:
-   *
-   * <ul>
-   *   <li>Gradle 5.1.0-M1 added {@code getArchiveFile}: <a
-   *       href="https://github.com/gradle/gradle/commit/aff5155fc0f281e407df70dd1712cc5c08571f21#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR122">commit</a>
-   *   <li>Gradle 5.1.0-M1 deprecated {@code getArchivePath}: <a
-   *       href="https://github.com/gradle/gradle/commit/5c458c522af58612f2bfa85568e07aa29e585931#">commit</a>
-   *   <li>Gradle 6.0.0-RC1 added nagging to {@code getArchivePath}: <a
-   *       href="https://github.com/gradle/gradle/commit/e3824ff38513762a9a9ed554d7b2161e5be7c31a#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR148">commit</a>
-   *   <li>Gradle 6.0.0-RC1 removed nagging of {@code getArchivePath}, because Kotlin plugin wasn't
-   *       ready: <a
-   *       href="https://github.com/gradle/gradle/commit/f3cafc74853d0c4d0720b6a1b8bc70a09e12c6c1#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR149">commit</a>
-   *   <li>Gradle 7.1.0-RC1 re-enabled nagging of {@code getArchivePath} for Gradle 8: <a
-   *       href="https://github.com/gradle/gradle/commit/d17832e975a5718e95bf65e8d67a341f78732ff6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR156">commit</a>
-   *   <li>Gradle 7.1.0-RC1 removed nagging of {@code getArchivePath}, because Kotlin plugin wasn't
-   *       ready: <a
-   *       href="https://github.com/gradle/gradle/commit/3107f771a53e847cc5cd4f543e134d86e15215b6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR110">commit</a>
-   *   <li>Gradle 8.0-M2 removed {@code getArchivePath}: <a
-   *       href="https://github.com/gradle/gradle/commit/dbbd4d6875ae9faad57f5677810793f83ea22399#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdL156">commit</a>
-   *   <li>Gradle 8.0-M2 re-added {@code getArchivePath} with nagging for Gradle 9, because Kotlin
-   *       plugin wasn't ready: <a
-   *       href="https://github.com/gradle/gradle/commit/96abd3e04369a8869bca0658369ccb002bb6fe7e#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR154">commit</a>
-   * </ul>
-   *
    * @param task the task whose archive location we're interested in.
    * @return the archive location as a {@link File} for compatibility with older Gradle versions.
    */
   @SuppressWarnings("deprecation")
   public static File getArchiveFile(AbstractArchiveTask task) {
+    // getArchiveFile and getArchivePath history:
+    //  - Gradle 5.1.0-M1 added `getArchiveFile`
+    //  - Gradle 5.1.0-M1 deprecated `getArchivePath`
+    //  - Gradle 6.0.0-RC1 added nagging to `getArchivePath`
+    //  - Gradle 6.0.0-RC1 removed nagging of `getArchivePath`
+    //  - Gradle 7.1.0-RC1 re-enabled nagging of `getArchivePath` for Gradle 8
+    //  - Gradle 7.1.0-RC1 removed nagging of `getArchivePath`
+    //  - Gradle 8.0-M2 removed `getArchivePath`
+    //  - Gradle 8.0-M2 re-added `getArchivePath` with nagging for Gradle 9
+    // For full history with references see:
+    // https://github.com/GoogleCloudPlatform/app-gradle-plugin/pull/451
+
     if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("5.1")) >= 0) {
       return task.getArchiveFile().get().getAsFile();
     } else {
-      // Note: in case this fails to compile, because Gradle have succeeded with the removal, this
-      // needs to be replaced with a reflective call to getArchivePath()
+      // Note: in case this fails to compile, because Gradle have succeeded with the removal,
+      // this needs to be replaced with a reflective call to getArchivePath()
       // or the minimum Gradle version for GCP Gradle Plugin bumped up to 5.1+.
       return task.getArchivePath();
     }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
@@ -7,6 +7,10 @@ import org.gradle.util.GradleVersion;
 /** Utility class for Gradle compatibility related functions. As an end user, do not use. */
 public class GradleCompatibility {
 
+  private GradleCompatibility() {
+    // Prevent instantiation and extension.
+  }
+
   /**
    * Compatibility method for getting the archive location.
    *

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
@@ -4,6 +4,7 @@ import java.io.File;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.util.GradleVersion;
 
+/** Utility class for Gradle compatibility related functions. As an end user, do not use. */
 public class GradleCompatibility {
 
   /**

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
@@ -23,6 +23,10 @@ import java.util.stream.Collectors;
 
 public class NullSafe {
 
+  private NullSafe() {
+    // Prevent instantiation and extension.
+  }
+
   public static <S, R> R convert(S source, Function<S, R> converter) {
     return (source == null) ? null : converter.apply(source);
   }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -190,7 +190,7 @@ public class AppEngineAppYamlPluginTest {
         testProjectDir.getRoot().toPath().toRealPath().resolve("src/main/appengine"),
         deployExt.getAppEngineDirectory().toPath());
     War war = (War) p.getProperties().get(WarPlugin.WAR_TASK_NAME);
-    assertEquals((war.getArchiveFile().get().getAsFile()), stageExt.getArtifact());
+    assertEquals(war.getArchiveFile().get().getAsFile(), stageExt.getArtifact());
     assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
 
     assertEquals("test-project", deployExt.getProjectId());
@@ -207,7 +207,7 @@ public class AppEngineAppYamlPluginTest {
 
     assertTrue(new File(testProjectDir.getRoot(), "src/main/docker").exists());
     Jar jar = (Jar) p.getProperties().get(JavaPlugin.JAR_TASK_NAME);
-    assertEquals((jar.getArchiveFile().get().getAsFile()), stageExt.getArtifact());
+    assertEquals(jar.getArchiveFile().get().getAsFile(), stageExt.getArtifact());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -33,6 +33,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.testkit.runner.BuildResult;
@@ -187,7 +189,8 @@ public class AppEngineAppYamlPluginTest {
     assertEquals(
         testProjectDir.getRoot().toPath().toRealPath().resolve("src/main/appengine"),
         deployExt.getAppEngineDirectory().toPath());
-    assertEquals((((War) p.getProperties().get("war")).getArchivePath()), stageExt.getArtifact());
+    War war = (War) p.getProperties().get(WarPlugin.WAR_TASK_NAME);
+    assertEquals((war.getArchivePath()), stageExt.getArtifact());
     assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
 
     assertEquals("test-project", deployExt.getProjectId());
@@ -203,7 +206,8 @@ public class AppEngineAppYamlPluginTest {
     StageAppYamlExtension stageExt = ext.getStage();
 
     assertTrue(new File(testProjectDir.getRoot(), "src/main/docker").exists());
-    assertEquals((((Jar) p.getProperties().get("jar")).getArchivePath()), stageExt.getArtifact());
+    Jar jar = (Jar) p.getProperties().get(JavaPlugin.JAR_TASK_NAME);
+    assertEquals((jar.getArchivePath()), stageExt.getArtifact());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -190,7 +190,7 @@ public class AppEngineAppYamlPluginTest {
         testProjectDir.getRoot().toPath().toRealPath().resolve("src/main/appengine"),
         deployExt.getAppEngineDirectory().toPath());
     War war = (War) p.getProperties().get(WarPlugin.WAR_TASK_NAME);
-    assertEquals((war.getArchivePath()), stageExt.getArtifact());
+    assertEquals((war.getArchiveFile().get().getAsFile()), stageExt.getArtifact());
     assertFalse(new File(testProjectDir.getRoot(), "src/main/docker").exists());
 
     assertEquals("test-project", deployExt.getProjectId());
@@ -207,7 +207,7 @@ public class AppEngineAppYamlPluginTest {
 
     assertTrue(new File(testProjectDir.getRoot(), "src/main/docker").exists());
     Jar jar = (Jar) p.getProperties().get(JavaPlugin.JAR_TASK_NAME);
-    assertEquals((jar.getArchivePath()), stageExt.getArtifact());
+    assertEquals((jar.getArchiveFile().get().getAsFile()), stageExt.getArtifact());
   }
 
   @Test


### PR DESCRIPTION
fixes #446 

Illustrious history of why deprecations should be handled as soon as they come up:

* Gradle 5.1.0-M1 added `getArchiveFile`: [commit](https://github.com/gradle/gradle/commit/aff5155fc0f281e407df70dd1712cc5c08571f21#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR122)
* Gradle 5.1.0-M1 deprecated `getArchivePath`: [commit](https://github.com/gradle/gradle/commit/5c458c522af58612f2bfa85568e07aa29e585931#)
* Gradle 6.0.0-RC1 added nagging to `getArchivePath`: [commit](https://github.com/gradle/gradle/commit/e3824ff38513762a9a9ed554d7b2161e5be7c31a#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR148)
* Gradle 6.0.0-RC1 removed nagging of `getArchivePath`, because Kotlin plugin wasn't ready: [commit](https://github.com/gradle/gradle/commit/f3cafc74853d0c4d0720b6a1b8bc70a09e12c6c1#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR149)
* Gradle 7.1.0-RC1 re-enabled nagging of `getArchivePath` for Gradle 8: [commit](https://github.com/gradle/gradle/commit/d17832e975a5718e95bf65e8d67a341f78732ff6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR156)
* Gradle 7.1.0-RC1 removed nagging of `getArchivePath`, because Kotlin plugin wasn't ready: [commit](https://github.com/gradle/gradle/commit/3107f771a53e847cc5cd4f543e134d86e15215b6#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR110)
* Gradle 8.0-M2 removed `getArchivePath`: [commit](https://github.com/gradle/gradle/commit/dbbd4d6875ae9faad57f5677810793f83ea22399#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdL156)
* Gradle 8.0-M2 re-added `getArchivePath` with nagging for Gradle 9, because Kotlin plugin wasn't ready: [commit](https://github.com/gradle/gradle/commit/96abd3e04369a8869bca0658369ccb002bb6fe7e#diff-54e324a7535f20d634929dafc00edb5bc8d287199f200cc50b57461e46a513cdR154)