### PR TITLE
Fix all known javadoc issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,7 +189,7 @@ tasks.check.configure {
 // to auto-format run ./gradlew googleJavaFormat
 
 checkstyle {
-  toolVersion = "8.18"
+  toolVersion = "9.3"
   // get the google_checks.xml file from the actual tool we"re invoking)
   config = resources.text.fromArchiveEntry(configurations.checkstyle.files.first(), "google_checks.xml")
   maxErrors = 0

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlExtension.java
@@ -25,6 +25,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 
+/** Extension element to define all configurations for App Engine app.yaml based projects. */
 public class AppEngineAppYamlExtension implements AppEngineCoreExtensionProperties {
   @InternalProperty private static final String TOOLS_EXT = "tools";
   @InternalProperty private static final String DEPLOY_EXT = "deploy";

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlExtension.java
@@ -34,7 +34,11 @@ public class AppEngineAppYamlExtension implements AppEngineCoreExtensionProperti
   @InternalProperty private DeployExtension deploy;
   @InternalProperty private StageAppYamlExtension stage;
 
-  /** Create nested configuration blocks as Extensions. */
+  /**
+   * Create nested configuration blocks as Extensions.
+   *
+   * @param project the {@link Project} to inject into the sub-extensions.
+   */
   public void createSubExtensions(Project project) {
     tools =
         ((ExtensionAware) this).getExtensions().create(TOOLS_EXT, ToolsExtension.class, project);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlExtension.java
@@ -83,7 +83,11 @@ public class StageAppYamlExtension {
     this.stagingDirectory = project.file(stagingDirectory);
   }
 
-  /** This method is purely for incremental build calculations. */
+  /**
+   * This method is purely for incremental build calculations.
+   *
+   * @return the extra files used in the build
+   */
   @Optional
   @InputFiles
   public FileCollection getExtraFilesDirectoriesAsInputFiles() {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
@@ -37,7 +37,11 @@ public class StageAppYamlTask extends DefaultTask {
     this.appYamlExtension = stagingConfig;
   }
 
-  /** Task entrypoint : Stage the app.yaml based application. */
+  /**
+   * Task entrypoint: Stage the app.yaml based application.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void stageAction() throws AppEngineException {
     getProject().delete(appYamlExtension.getStagingDirectory());

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCoreExtensionProperties.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCoreExtensionProperties.java
@@ -17,6 +17,7 @@
 
 package com.google.cloud.tools.gradle.appengine.core;
 
+/** Core extension properties to share configuration between plugins. */
 public interface AppEngineCoreExtensionProperties {
   ToolsExtension getTools();
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -56,7 +56,15 @@ public class AppEngineCorePluginConfiguration {
   private boolean requiresAppEngineJava;
   private String taskGroup;
 
-  /** Configure core tasks for appengine app.yaml and appengine-web.xml based project plugins. */
+  /**
+   * Configure core tasks for appengine app.yaml and appengine-web.xml based project plugins.
+   *
+   * @param project to apply this plugin to
+   * @param appEngineCoreExtensionProperties the extension hierarchy that will be used for
+   *     configuring the plugin
+   * @param taskGroup Gradle task group which will be set on all tasks created by this plugin
+   * @param requiresAppEngineJava whether it is necessary to use the AppEngine Java SDK
+   */
   public void configureCoreProperties(
       Project project,
       AppEngineCoreExtensionProperties appEngineCoreExtensionProperties,

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 
+/** Task to verify cloud SDK installation is ready to use. */
 public class CheckCloudSdkTask extends DefaultTask {
 
   private CloudSdk cloudSdk;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CheckCloudSdkTask.java
@@ -45,7 +45,15 @@ public class CheckCloudSdkTask extends DefaultTask {
     this.requiresAppEngineJava = requiresAppEngineJava;
   }
 
-  /** Task entrypoint : Verify Cloud SDK installation. */
+  /**
+   * Task entrypoint: Verify Cloud SDK installation.
+   *
+   * @throws CloudSdkNotFoundException if gcloud validation fails, so the Gradle task fails.
+   * @throws CloudSdkVersionFileException if gcloud validation fails, so the Gradle task fails.
+   * @throws CloudSdkOutOfDateException if gcloud validation fails, so the Gradle task fails.
+   * @throws AppEngineJavaComponentsNotInstalledException if gcloud validation fails, so the Gradle
+   *     task fails.
+   */
   @TaskAction
   public void checkCloudSdkAction()
       throws CloudSdkNotFoundException, CloudSdkVersionFileException, CloudSdkOutOfDateException,

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkLoginTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkLoginTask.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.appengine.AppEngineException;
 import com.google.cloud.tools.appengine.operations.Gcloud;
 import org.gradle.api.tasks.TaskAction;
 
+/** Task to authenticate in the cloud SDK installation. */
 public class CloudSdkLoginTask extends GcloudTask {
 
   private Gcloud gcloud;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkLoginTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkLoginTask.java
@@ -29,7 +29,11 @@ public class CloudSdkLoginTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Login by delegating to gcloud auth login. */
+  /**
+   * Login by delegating to gcloud auth login.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void login() throws AppEngineException {
     gcloud.newAuth(CloudSdkOperations.getDefaultHandler(getLogger())).login();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
@@ -66,7 +66,9 @@ public class CloudSdkOperations {
 
   /**
    * DevServers isn't initialized at construction time, because we optionally download the appengine
-   * component for appengine-web.xml based applications
+   * component for appengine-web.xml based applications.
+   *
+   * @return the {@link DevServers} factory.
    */
   public DevServers getDevServers() {
     return DevServers.builder(cloudSdk).build();
@@ -74,13 +76,19 @@ public class CloudSdkOperations {
 
   /**
    * AppCfg isn't initialized at construction time, because we optionally download the appengine
-   * component for appengine-web.xml based applications
+   * component for appengine-web.xml based applications.
+   *
+   * @return the {@link AppCfg} factory.
    */
   public AppCfg getAppcfg() {
     return AppCfg.builder(cloudSdk).build();
   }
 
-  /** Create a return a new default configured process handler. */
+  /**
+   * Create a return a new default configured process handler.
+   *
+   * @return a default handler for the specified {@code logger}
+   */
   public static ProcessHandler getDefaultHandler(Logger logger) {
     return LegacyProcessHandler.builder()
         .addStdErrLineListener(logger::lifecycle)

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/CloudSdkOperations.java
@@ -87,6 +87,7 @@ public class CloudSdkOperations {
   /**
    * Create a return a new default configured process handler.
    *
+   * @param logger the Gradle logger to use for process output and error streams.
    * @return a default handler for the specified {@code logger}
    */
   public static ProcessHandler getDefaultHandler(Logger logger) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTask.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
 
+/** Task to deploy app and all configuration files (cron, dispatch, dos, datastore index, queue). */
 public class DeployAllTask extends GcloudTask {
 
   private DeployExtension deployExtension;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployAllTask.java
@@ -46,7 +46,11 @@ public class DeployAllTask extends GcloudTask {
     this.stageDirectory = stageDirectory;
   }
 
-  /** Task Entrypoint : Deploys the app and all of its config files. */
+  /**
+   * Task entrypoint: Deploys the app and all of its config files.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAllAction() throws AppEngineException {
     List<Path> deployables = new ArrayList<>();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployCronTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployCronTask.java
@@ -35,7 +35,11 @@ public class DeployCronTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task Entrypoint : deploy cron.yaml. */
+  /**
+   * Task entrypoint: deploy cron.yaml.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployDispatchTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployDispatchTask.java
@@ -36,7 +36,11 @@ public class DeployDispatchTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task entrypoint : deploy dispatch.yaml. */
+  /**
+   * Task entrypoint: deploy dispatch.yaml.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployDosTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployDosTask.java
@@ -35,7 +35,11 @@ public class DeployDosTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task entrypoint : deploy dos.yaml. */
+  /**
+   * Task entrypoint: deploy dos.yaml.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployIndexTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployIndexTask.java
@@ -35,7 +35,11 @@ public class DeployIndexTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task entrypoint : deploy index.yaml. */
+  /**
+   * Task entrypoint: deploy index.yaml.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployQueueTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployQueueTask.java
@@ -35,7 +35,11 @@ public class DeployQueueTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task entrypoint : deploy queue.yaml. */
+  /**
+   * Task entrypoint: deploy queue.yaml.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
@@ -58,6 +58,7 @@ public class DeployTargetResolver {
    * Process user configuration of "projectId". If set to GCLOUD_CONFIG then read from gcloud's
    * global state. If set but not a keyword then just return the set value.
    *
+   * @param configString the value of the configuration set by the user
    * @return what cloud project should be used for deployment
    */
   public String getProject(String configString) {
@@ -88,6 +89,7 @@ public class DeployTargetResolver {
    * Process user configuration of "version". If set to GCLOUD_CONFIG then allow gcloud to generate
    * a version. If set but not a keyword then just return the set value.
    *
+   * @param configString the value of the configuration set by the user
    * @return what cloud project version should be used for deployment
    */
   public String getVersion(String configString) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTargetResolver.java
@@ -57,6 +57,8 @@ public class DeployTargetResolver {
   /**
    * Process user configuration of "projectId". If set to GCLOUD_CONFIG then read from gcloud's
    * global state. If set but not a keyword then just return the set value.
+   *
+   * @return what cloud project should be used for deployment
    */
   public String getProject(String configString) {
     if (configString == null
@@ -85,6 +87,8 @@ public class DeployTargetResolver {
   /**
    * Process user configuration of "version". If set to GCLOUD_CONFIG then allow gcloud to generate
    * a version. If set but not a keyword then just return the set value.
+   *
+   * @return what cloud project version should be used for deployment
    */
   public String getVersion(String configString) {
     if (configString == null

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DeployTask.java
@@ -43,7 +43,11 @@ public class DeployTask extends GcloudTask {
     this.gcloud = gcloud;
   }
 
-  /** Task Entrypoint : DeployExtension application (via app.yaml). */
+  /**
+   * Task entrypoint: DeployExtension application (via app.yaml).
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void deployAction() throws AppEngineException {
     DeployConfiguration deployConfig =

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -38,6 +38,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
+/** Task to download Cloud SDK and install necessary components. */
 public class DownloadCloudSdkTask extends DefaultTask {
 
   private ManagedCloudSdk managedCloudSdk;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -57,7 +57,17 @@ public class DownloadCloudSdkTask extends DefaultTask {
     return ImmutableList.copyOf(components);
   }
 
-  /** Task entrypoint : Download/update Cloud SDK. */
+  /**
+   * Task entrypoint: Download/update Cloud SDK.
+   *
+   * @throws ManagedSdkVerificationException if gcloud command fails, so the Gradle task fails.
+   * @throws ManagedSdkVersionMismatchException if SDK installation fails, so the Gradle task fails.
+   * @throws InterruptedException if gcloud command fails, so the Gradle task fails.
+   * @throws CommandExecutionException if gcloud command fails, so the Gradle task fails.
+   * @throws SdkInstallerException if SDK installation fails, so the Gradle task fails.
+   * @throws CommandExitException if gcloud command fails, so the Gradle task fails.
+   * @throws IOException if SDK installation fails, so the Gradle task fails.
+   */
   @TaskAction
   public void downloadCloudSdkAction()
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException,

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskConsoleListener.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskConsoleListener.java
@@ -21,6 +21,10 @@ import com.google.cloud.tools.managedcloudsdk.ConsoleListener;
 import org.gradle.api.Project;
 import org.gradle.api.logging.LogLevel;
 
+/**
+ * Console listener for the {@link DownloadCloudSdkTask Cloud SDK download task}, forwarding output
+ * to Gradle console when possible.
+ */
 public class DownloadCloudSdkTaskConsoleListener implements ConsoleListener {
   private Project project;
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/GcloudTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/GcloudTask.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine.core;
 import com.google.cloud.tools.appengine.operations.Gcloud;
 import org.gradle.api.DefaultTask;
 
+/** Base task for all tasks that need {@link Gcloud} access. */
 public abstract class GcloudTask extends DefaultTask {
   public abstract void setGcloud(Gcloud gcloud);
 }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
 import com.google.cloud.tools.managedcloudsdk.Version;
 import com.google.common.base.Strings;
 
+/** Factory for creating {@link ManagedCloudSdk} instances. */
 public class ManagedCloudSdkFactory {
 
   private String version;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
@@ -31,7 +31,13 @@ public class ManagedCloudSdkFactory {
     this.version = version;
   }
 
-  /** Build a new ManagedCloudSdk from a given version. */
+  /**
+   * Build a new ManagedCloudSdk from a given version.
+   *
+   * @throws UnsupportedOsException if operating system is not supported by the managed SDK.
+   * @throws BadCloudSdkVersionException if managed SDK doesn't support the specific {@link
+   *     #version}.
+   */
   public ManagedCloudSdk newManagedSdk()
       throws UnsupportedOsException, BadCloudSdkVersionException {
     if (Strings.isNullOrEmpty(version)) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ManagedCloudSdkFactory.java
@@ -34,6 +34,7 @@ public class ManagedCloudSdkFactory {
   /**
    * Build a new ManagedCloudSdk from a given version.
    *
+   * @return a new {@link ManagedCloudSdk} with the default or specified {@link #version}.
    * @throws UnsupportedOsException if operating system is not supported by the managed SDK.
    * @throws BadCloudSdkVersionException if managed SDK doesn't support the specific {@link
    *     #version}.

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/ShowConfigurationTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/ShowConfigurationTask.java
@@ -46,7 +46,11 @@ public class ShowConfigurationTask extends DefaultTask {
     this.extensionId = extensionId;
   }
 
-  /** Task entrypoint : Log out configuration to lifecyle. */
+  /**
+   * Task entrypoint: Log out configuration to lifecyle.
+   *
+   * @throws IllegalAccessException if reflection fails, so the Gradle task fails.
+   */
   @TaskAction
   public void showConfiguration() throws IllegalAccessException {
     Object extensionInstance = getProject().getExtensions().getByName(extensionId);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/GenRepoInfoFileExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/GenRepoInfoFileExtension.java
@@ -32,7 +32,11 @@ public class GenRepoInfoFileExtension {
   private File outputDirectory;
   private File sourceDirectory;
 
-  /** Constructor. */
+  /**
+   * Constructor.
+   *
+   * @param project used to resolve files later in the lifecycle.
+   */
   public GenRepoInfoFileExtension(Project project) {
     this.project = project;
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/GenRepoInfoFileTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/sourcecontext/GenRepoInfoFileTask.java
@@ -43,7 +43,11 @@ public class GenRepoInfoFileTask extends DefaultTask {
     this.gcloud = gcloud;
   }
 
-  /** Task entrypoint : generate source context file. */
+  /**
+   * Task entrypoint: generate source context file.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void generateRepositoryInfoFile() throws AppEngineException {
     gcloud

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtension.java
@@ -36,7 +36,11 @@ public class AppEngineStandardExtension implements AppEngineCoreExtensionPropert
   @InternalProperty private StageStandardExtension stage;
   @InternalProperty private RunExtension run;
 
-  /** Create nested configuration blocks as Extensions. */
+  /**
+   * Create nested configuration blocks as Extensions.
+   *
+   * @param project the {@link Project} to inject into the sub-extensions.
+   */
   public void createSubExtensions(Project project) {
     tools =
         ((ExtensionAware) this).getExtensions().create(TOOLS_EXT, ToolsExtension.class, project);

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardExtension.java
@@ -25,6 +25,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 
+/** Extension element to define all configurations for App Engine Standard environment. */
 public class AppEngineStandardExtension implements AppEngineCoreExtensionProperties {
   @InternalProperty private static final String TOOLS_EXT = "tools";
   @InternalProperty private static final String DEPLOY_EXT = "deploy";

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerRunTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerRunTask.java
@@ -38,7 +38,11 @@ public class DevAppServerRunTask extends DefaultTask {
     this.devServers = devServers;
   }
 
-  /** Task entrypoint : run the devappserver (blocking). */
+  /**
+   * Task entrypoint: run the devappserver (blocking).
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void runAction() throws AppEngineException, ProjectConfigurationException {
     devServers

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStartTask.java
@@ -59,7 +59,13 @@ public class DevAppServerStartTask extends DefaultTask {
     return devAppServerLoggingDir;
   }
 
-  /** Task entrypoint : start the dev appserver (non-blocking). */
+  /**
+   * Task entrypoint: start the dev appserver (non-blocking).
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   * @throws IOException if there's a problem with {@link #devAppServerLoggingDir}, so the Gradle
+   *     task fails.
+   */
   @TaskAction
   public void startAction() throws AppEngineException, IOException {
 

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/DevAppServerStopTask.java
@@ -38,7 +38,7 @@ public class DevAppServerStopTask extends DefaultTask {
     this.devServers = devServers;
   }
 
-  /** Task entrypoint : Stop the dev appserver (get StopConfiguration from helper). */
+  /** Task entrypoint: Stop the dev appserver (get StopConfiguration from helper). */
   @TaskAction
   public void stopAction() {
     DevServer server =

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/ExplodeWarTask.java
@@ -31,8 +31,10 @@ public class ExplodeWarTask extends Sync {
   }
 
   /**
-   * Sets the output directory of Sync Task and preserves the setting so it can be recovered later
+   * Sets the output directory of Sync Task and preserves the setting, so it can be recovered later
    * via getter.
+   *
+   * @param explodedAppDirectory the output directory of explode task.
    */
   public void setExplodedAppDirectory(File explodedAppDirectory) {
     this.explodedAppDirectory = explodedAppDirectory;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -130,6 +130,8 @@ public class RunExtension {
   /**
    * Returns the appengine service directory for this project and modifies the task dependencies of
    * run/start to ensure {@code serviceProject} is built first.
+   *
+   * @return the output directory of the {@code serviceProject}
    */
   public File projectAsService(String serviceProject) {
     return projectAsService(project.getRootProject().project(serviceProject));
@@ -138,6 +140,8 @@ public class RunExtension {
   /**
    * Returns the appengine service directory for this project and modifies the task dependencies of
    * run/start to ensure {@code serviceProject} is built first.
+   *
+   * @return the output directory of the {@code serviceProject}
    */
   public File projectAsService(Project serviceProject) {
     if (!serviceProject.equals(project)) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/RunExtension.java
@@ -131,6 +131,7 @@ public class RunExtension {
    * Returns the appengine service directory for this project and modifies the task dependencies of
    * run/start to ensure {@code serviceProject} is built first.
    *
+   * @param serviceProject the project containing the classes that will be deployed.
    * @return the output directory of the {@code serviceProject}
    */
   public File projectAsService(String serviceProject) {
@@ -141,6 +142,7 @@ public class RunExtension {
    * Returns the appengine service directory for this project and modifies the task dependencies of
    * run/start to ensure {@code serviceProject} is built first.
    *
+   * @param serviceProject the project containing the classes that will be deployed.
    * @return the output directory of the {@code serviceProject}
    */
   public File projectAsService(Project serviceProject) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardExtension.java
@@ -45,7 +45,11 @@ public class StageStandardExtension {
   private Boolean disableJarJsps;
   private String runtime;
 
-  /** Constuctor. */
+  /**
+   * Constuctor.
+   *
+   * @param project used to resolve files later in the lifecycle.
+   */
   public StageStandardExtension(Project project) {
     this.project = project;
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/standard/StageStandardTask.java
@@ -43,7 +43,11 @@ public class StageStandardTask extends DefaultTask {
     this.appCfg = appCfg;
   }
 
-  /** Task entrypoint : stage the standard app. */
+  /**
+   * Task entrypoint: stage the standard app.
+   *
+   * @throws AppEngineException if gcloud command fails, so the Gradle task fails.
+   */
   @TaskAction
   public void stageAction() throws AppEngineException {
     getProject().delete(stageStandardExtension.getStagingDirectory());

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/AppEngineWebXml.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/AppEngineWebXml.java
@@ -49,7 +49,11 @@ public class AppEngineWebXml {
     return new AppEngineWebXml(appengineWebXml);
   }
 
-  /** Check if vm = true. */
+  /**
+   * Check the value of the {@code vm} element.
+   *
+   * @return {@code true} if {@code vm = true} in the XML configuration.
+   */
   public boolean isVm() {
     try {
       XPath xpath = XPathFactory.newInstance().newXPath();

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
@@ -29,7 +29,7 @@ public class ExtensionUtil {
   }
 
   /**
-   * Get an extension by it's path, potentially will throw all kinds of exceptions. Be very careful.
+   * Get an extension by its path, potentially will throw all kinds of exceptions. Be very careful.
    *
    * @param path individual extension names leading to the extension you want to access.
    * @param <T> the final type of the deeply nested extension, convenience unchecked conversion, be

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
@@ -30,6 +30,8 @@ public class ExtensionUtil {
 
   /**
    * Get an extension by it's path, potentially will throw all kinds of exceptions. Be very careful.
+   *
+   * @return the value of the extension at the leaf
    */
   @SuppressWarnings("unchecked")
   public <T> T get(String... path) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
@@ -31,6 +31,9 @@ public class ExtensionUtil {
   /**
    * Get an extension by it's path, potentially will throw all kinds of exceptions. Be very careful.
    *
+   * @param path individual extension names leading to the extension you want to access.
+   * @param <T> the final type of the deeply nested extension, convenience unchecked conversion, be
+   *     careful.
    * @return the value of the extension at the leaf
    */
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/ExtensionUtil.java
@@ -20,6 +20,7 @@ package com.google.cloud.tools.gradle.appengine.util;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.ExtensionContainer;
 
+/** Utility class for operating on Gradle extensions. */
 public class ExtensionUtil {
 
   private final ExtensionAware searchRoot;

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/NullSafe.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/** Utility class for null-safe conversions. */
 public class NullSafe {
 
   public static <S, R> R convert(S source, Function<S, R> converter) {


### PR DESCRIPTION
<details><summary><code>gradlew javadoc</code></summary>

```
> Task :javadoc
src\main\java\com\google\cloud\tools\gradle\appengine\standard\AppEngineStandardExtension.java:40:
warning: no @param for project
  public void createSubExtensions(Project project) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\DevAppServerRunTask.java:43:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void runAction() throws AppEngineException, ProjectConfigurationException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\DevAppServerStartTask.java:64:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void startAction() throws AppEngineException, IOException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\DevAppServerStartTask.java:64:
warning: no @throws for java.io.IOException
  public void startAction() throws AppEngineException, IOException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\ExplodeWarTask.java:37:
warning: no @param for explodedAppDirectory
  public void setExplodedAppDirectory(File explodedAppDirectory) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\RunExtension.java:134:
warning: no @param for serviceProject
  public File projectAsService(String serviceProject) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\RunExtension.java:134:
warning: no @return
  public File projectAsService(String serviceProject) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\RunExtension.java:142:
warning: no @param for serviceProject
  public File projectAsService(Project serviceProject) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\RunExtension.java:142:
warning: no @return
  public File projectAsService(Project serviceProject) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\StageStandardExtension.java:49:
warning: no @param for project
  public StageStandardExtension(Project project) {
         ^
src\main\java\com\google\cloud\tools\gradle\appengine\standard\StageStandardTask.java:48:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void stageAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\AppEngineCorePluginConfiguration.java:60:
warning: no @param for project
  public void configureCoreProperties(
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\AppEngineCorePluginConfiguration.java:60:
warning: no @param for appEngineCoreExtensionProperties
  public void configureCoreProperties(
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\AppEngineCorePluginConfiguration.java:60:
warning: no @param for taskGroup
  public void configureCoreProperties(
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\AppEngineCorePluginConfiguration.java:60:
warning: no @param for requiresAppEngineJava
  public void configureCoreProperties(
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CheckCloudSdkTask.java:50:
warning: no @throws for com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkNotFoundException
  public void checkCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CheckCloudSdkTask.java:50:
warning: no @throws for com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkVersionFileException
  public void checkCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CheckCloudSdkTask.java:50:
warning: no @throws for com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkOutOfDateException
  public void checkCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CheckCloudSdkTask.java:50:
warning: no @throws for com.google.cloud.tools.appengine.operations.cloudsdk.AppEngineJavaComponentsNotInst
alledException
  public void checkCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkLoginTask.java:34:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void login() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkOperations.java:71:
warning: no @return
  public DevServers getDevServers() {
                    ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkOperations.java:79:
warning: no @return
  public AppCfg getAppcfg() {
                ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkOperations.java:84:
warning: no @param for logger
  public static ProcessHandler getDefaultHandler(Logger logger) {
                               ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkOperations.java:84:
warning: no @return
  public static ProcessHandler getDefaultHandler(Logger logger) {
                               ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployAllTask.java:51:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAllAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployCronTask.java:40:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployDispatchTask.java:41:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployDosTask.java:40:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployIndexTask.java:40:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployQueueTask.java:40:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployTargetResolver.java:61:
warning: no @param for configString
  public String getProject(String configString) {
                ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployTargetResolver.java:61:
warning: no @return
  public String getProject(String configString) {
                ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployTargetResolver.java:89:
warning: no @param for configString
  public String getVersion(String configString) {
                ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployTargetResolver.java:89:
warning: no @return
  public String getVersion(String configString) {
                ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployTask.java:48:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void deployAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.ManagedSdkVerificationException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.ManagedSdkVersionMismatchException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for java.lang.InterruptedException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.command.CommandExecutionException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.install.SdkInstallerException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.command.CommandExitException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:62:
warning: no @throws for java.io.IOException
  public void downloadCloudSdkAction()
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\ManagedCloudSdkFactory.java:35:
warning: no @return
  public ManagedCloudSdk newManagedSdk()
                         ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\ManagedCloudSdkFactory.java:35:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.UnsupportedOsException
  public ManagedCloudSdk newManagedSdk()
                         ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\ManagedCloudSdkFactory.java:35:
warning: no @throws for com.google.cloud.tools.managedcloudsdk.BadCloudSdkVersionException
  public ManagedCloudSdk newManagedSdk()
                         ^
src\main\java\com\google\cloud\tools\gradle\appengine\core\ShowConfigurationTask.java:51:
warning: no @throws for java.lang.IllegalAccessException
  public void showConfiguration() throws IllegalAccessException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\sourcecontext\GenRepoInfoFileExtension.java:36:
warning: no @param for project
  public GenRepoInfoFileExtension(Project project) {
         ^
src\main\java\com\google\cloud\tools\gradle\appengine\sourcecontext\GenRepoInfoFileTask.java:48:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void generateRepositoryInfoFile() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\appyaml\AppEngineAppYamlExtension.java:38:
warning: no @param for project
  public void createSubExtensions(Project project) {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\appyaml\StageAppYamlExtension.java:89:
warning: no @return
  public FileCollection getExtraFilesDirectoriesAsInputFiles() {
                        ^
src\main\java\com\google\cloud\tools\gradle\appengine\appyaml\StageAppYamlTask.java:42:
warning: no @throws for com.google.cloud.tools.appengine.AppEngineException
  public void stageAction() throws AppEngineException {
              ^
src\main\java\com\google\cloud\tools\gradle\appengine\util\AppEngineWebXml.java:53:
warning: no @return
  public boolean isVm() {
                 ^
src\main\java\com\google\cloud\tools\gradle\appengine\util\ExtensionUtil.java:35:
warning: no @param for <T>
  public <T> T get(String... path) {
               ^
src\main\java\com\google\cloud\tools\gradle\appengine\util\ExtensionUtil.java:35:
warning: no @param for path
  public <T> T get(String... path) {
               ^
src\main\java\com\google\cloud\tools\gradle\appengine\util\ExtensionUtil.java:35:
warning: no @return
  public <T> T get(String... path) {
               ^
55 warnings
```
</details>

<details><summary><code>gradlew checkstyleMain</code></summary>

```
> Task :checkstyleMain
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\appyaml\AppEngineAppYamlExtension.java:28:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\AppEngineCoreExtensionProperties.java:20:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\CheckCloudSdkTask.java:30:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\CloudSdkLoginTask.java:24:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\DeployAllTask.java:31:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTask.java:41:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\DownloadCloudSdkTaskConsoleListener.java:24:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\GcloudTask.java:23:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\core\ManagedCloudSdkFactory.java:26:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\standard\AppEngineStandardExtension.java:28:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\util\ExtensionUtil.java:23:1: Missing a Javadoc comment. [MissingJavadocType]
[ant:checkstyle] [WARN] src\main\java\com\google\cloud\tools\gradle\appengine\util\NullSafe.java:24:1: Missing a Javadoc comment. [MissingJavadocType]
```
</details>