### PR TITLE
chore: update GRADLE_MIN_VERSION in check and test suite to 4.0

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
@@ -35,9 +35,6 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEnginePlugin implements Plugin<Project> {
 
-  private static final GradleVersion GRADLE_MIN_VERSION =
-      GradleCompatibility.getMinimumGradleVersion();
-
   @Override
   public void apply(Project project) {
     checkGradleVersion();
@@ -65,12 +62,12 @@ public class AppEnginePlugin implements Plugin<Project> {
   }
 
   private void checkGradleVersion() {
-    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
+    if (GradleCompatibility.getMinimumGradleVersion().compareTo(GradleVersion.current()) > 0) {
       throw new GradleException(
           "Detected "
               + GradleVersion.current()
               + ", but the appengine-gradle-plugin requires "
-              + GRADLE_MIN_VERSION
+              + GradleCompatibility.getMinimumGradleVersion()
               + " or higher.");
     }
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
@@ -34,7 +34,7 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEnginePlugin implements Plugin<Project> {
 
-  private static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("3.4.1");
+  private static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.0");
 
   @Override
   public void apply(Project project) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/AppEnginePlugin.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.gradle.appengine;
 
 import com.google.cloud.tools.gradle.appengine.appyaml.AppEngineAppYamlPlugin;
 import com.google.cloud.tools.gradle.appengine.standard.AppEngineStandardPlugin;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.gradle.api.GradleException;
@@ -34,7 +35,8 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEnginePlugin implements Plugin<Project> {
 
-  private static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.0");
+  private static final GradleVersion GRADLE_MIN_VERSION =
+      GradleCompatibility.getMinimumGradleVersion();
 
   @Override
   public void apply(Project project) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -18,6 +18,7 @@
 package com.google.cloud.tools.gradle.appengine.core;
 
 import com.google.cloud.tools.appengine.operations.cloudsdk.CloudSdkNotFoundException;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import com.google.cloud.tools.managedcloudsdk.BadCloudSdkVersionException;
 import com.google.cloud.tools.managedcloudsdk.ManagedCloudSdk;
 import com.google.cloud.tools.managedcloudsdk.UnsupportedOsException;
@@ -32,7 +33,8 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEngineCorePluginConfiguration {
 
-  public static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.0");
+  public static final GradleVersion GRADLE_MIN_VERSION =
+      GradleCompatibility.getMinimumGradleVersion();
 
   public static final String LOGIN_TASK_NAME = "appengineCloudSdkLogin";
   public static final String DEPLOY_TASK_NAME = "appengineDeploy";

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -33,9 +33,6 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEngineCorePluginConfiguration {
 
-  public static final GradleVersion GRADLE_MIN_VERSION =
-      GradleCompatibility.getMinimumGradleVersion();
-
   public static final String LOGIN_TASK_NAME = "appengineCloudSdkLogin";
   public static final String DEPLOY_TASK_NAME = "appengineDeploy";
   public static final String DEPLOY_CRON_TASK_NAME = "appengineDeployCron";
@@ -338,12 +335,12 @@ public class AppEngineCorePluginConfiguration {
   }
 
   private void checkGradleVersion() {
-    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
+    if (GradleCompatibility.getMinimumGradleVersion().compareTo(GradleVersion.current()) > 0) {
       throw new GradleException(
           "Detected "
               + GradleVersion.current()
               + ", but the appengine-gradle-plugin requires "
-              + GRADLE_MIN_VERSION
+              + GradleCompatibility.getMinimumGradleVersion()
               + " or higher.");
     }
   }

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/AppEngineCorePluginConfiguration.java
@@ -32,7 +32,7 @@ import org.gradle.util.GradleVersion;
  */
 public class AppEngineCorePluginConfiguration {
 
-  public static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("3.4.1");
+  public static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.0");
 
   public static final String LOGIN_TASK_NAME = "appengineCloudSdkLogin";
   public static final String DEPLOY_TASK_NAME = "appengineDeploy";

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/util/GradleCompatibility.java
@@ -12,6 +12,16 @@ public class GradleCompatibility {
   }
 
   /**
+   * Method for getting the minimum version of Gradle supported by the plugin, for use in
+   * enforcement checks and test suite.
+   *
+   * @return the minimum compatible {@link GradleVersion}.
+   */
+  public static GradleVersion getMinimumGradleVersion() {
+    return GradleVersion.version("4.0");
+  }
+
+  /**
    * Compatibility method for getting the archive location.
    *
    * @param task the task whose archive location we're interested in.

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/AppEnginePluginTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.appyaml.AppEngineAppYamlPlugin;
-import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfiguration;
 import com.google.cloud.tools.gradle.appengine.standard.AppEngineStandardPlugin;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import java.io.IOException;
 import org.gradle.api.Project;
 import org.gradle.testkit.runner.BuildResult;
@@ -49,7 +49,7 @@ public class AppEnginePluginTest {
     assumeTrue(isJava8Runtime());
     new TestProject(testProjectRoot.getRoot())
         .applyGradleRunnerWithGradleVersion(
-            AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
+            GradleCompatibility.getMinimumGradleVersion().getVersion());
     // pass
   }
 
@@ -65,7 +65,7 @@ public class AppEnginePluginTest {
           ex.getMessage(),
           containsString(
               "Detected Gradle 2.8, but the appengine-gradle-plugin requires "
-                  + AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION
+                  + GradleCompatibility.getMinimumGradleVersion()
                   + " or higher."));
     }
   }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/appyaml/AppEngineAppYamlPluginTest.java
@@ -26,8 +26,8 @@ import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.BuildResultFilter;
 import com.google.cloud.tools.gradle.appengine.TestProject;
-import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfiguration;
 import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class AppEngineAppYamlPluginTest {
     assumeTrue(isJava8Runtime());
     createTestProject()
         .applyGradleRunnerWithGradleVersion(
-            AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
+            GradleCompatibility.getMinimumGradleVersion().getVersion());
     // pass
   }
 
@@ -79,7 +79,7 @@ public class AppEngineAppYamlPluginTest {
           ex.getMessage(),
           containsString(
               "Detected Gradle 2.8, but the appengine-gradle-plugin requires "
-                  + AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION
+                  + GradleCompatibility.getMinimumGradleVersion()
                   + " or higher."));
     }
   }

--- a/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
+++ b/src/test/java/com/google/cloud/tools/gradle/appengine/standard/AppEngineStandardPluginTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.tools.gradle.appengine.BuildResultFilter;
 import com.google.cloud.tools.gradle.appengine.TestProject;
-import com.google.cloud.tools.gradle.appengine.core.AppEngineCorePluginConfiguration;
 import com.google.cloud.tools.gradle.appengine.core.DeployExtension;
+import com.google.cloud.tools.gradle.appengine.util.GradleCompatibility;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
@@ -69,7 +69,7 @@ public class AppEngineStandardPluginTest {
     assumeTrue(isJava8Runtime());
     createTestProject()
         .applyGradleRunnerWithGradleVersion(
-            AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION.getVersion());
+            GradleCompatibility.getMinimumGradleVersion().getVersion());
     // pass
   }
 
@@ -83,7 +83,7 @@ public class AppEngineStandardPluginTest {
           ex.getMessage(),
           containsString(
               "Detected Gradle 2.8, but the appengine-gradle-plugin requires "
-                  + AppEngineCorePluginConfiguration.GRADLE_MIN_VERSION
+                  + GradleCompatibility.getMinimumGradleVersion()
                   + " or higher."));
     }
   }


### PR DESCRIPTION
This PR updates `GRADLE_MIN_VERSION` used in checks and test suite to 4.0 to align with documentation in [README](https://github.com/GoogleCloudPlatform/app-gradle-plugin/blob/ba077249835eebc9cc264c2bb0424e5d9ba41acf/README.md?plain=1#L14), along with refactoring suggested in https://github.com/GoogleCloudPlatform/app-gradle-plugin/issues/450#issuecomment-1384182161.

Resolves #450.