### PR TITLE
Remove usage of Project during task execution

### DIFF
--- a/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/appyaml/StageAppYamlTask.java
@@ -19,12 +19,17 @@ package com.google.cloud.tools.gradle.appengine.appyaml;
 
 import com.google.cloud.tools.appengine.AppEngineException;
 import com.google.cloud.tools.appengine.operations.AppYamlProjectStaging;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 
 /** Stage App Engine app.yaml based applications for deployment. */
-public class StageAppYamlTask extends DefaultTask {
+public abstract class StageAppYamlTask extends DefaultTask {
+
+  @Inject
+  abstract public FileOperations getFileOperations();
 
   private StageAppYamlExtension appYamlExtension;
 
@@ -40,8 +45,8 @@ public class StageAppYamlTask extends DefaultTask {
   /** Task entrypoint : Stage the app.yaml based application. */
   @TaskAction
   public void stageAction() throws AppEngineException {
-    getProject().delete(appYamlExtension.getStagingDirectory());
-    getProject().mkdir(appYamlExtension.getStagingDirectory().getAbsolutePath());
+    getFileOperations().delete(appYamlExtension.getStagingDirectory());
+    getFileOperations().mkdir(appYamlExtension.getStagingDirectory().getAbsolutePath());
 
     AppYamlProjectStaging staging = new AppYamlProjectStaging();
     staging.stageArchive(appYamlExtension.toAppYamlProjectStageConfiguration());

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTask.java
@@ -69,7 +69,7 @@ public class DownloadCloudSdkTask extends DefaultTask {
     }
 
     ProgressListener progressListener = new NoOpProgressListener();
-    ConsoleListener consoleListener = new DownloadCloudSdkTaskConsoleListener(getProject());
+    ConsoleListener consoleListener = new DownloadCloudSdkTaskConsoleListener(getLogger());
 
     // Install sdk if not installed
     if (!managedCloudSdk.isInstalled()) {

--- a/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskConsoleListener.java
+++ b/src/main/java/com/google/cloud/tools/gradle/appengine/core/DownloadCloudSdkTaskConsoleListener.java
@@ -20,12 +20,13 @@ package com.google.cloud.tools.gradle.appengine.core;
 import com.google.cloud.tools.managedcloudsdk.ConsoleListener;
 import org.gradle.api.Project;
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
 
 public class DownloadCloudSdkTaskConsoleListener implements ConsoleListener {
-  private Project project;
+  private Logger logger;
 
-  public DownloadCloudSdkTaskConsoleListener(Project project) {
-    this.project = project;
+  public DownloadCloudSdkTaskConsoleListener(Logger logger) {
+    this.logger = logger;
   }
 
   @Override
@@ -36,7 +37,7 @@ public class DownloadCloudSdkTaskConsoleListener implements ConsoleListener {
     // is that Gradle redirects standard output to its logging system at the QUIET level. So, in
     // order to print to LIFECYCLE without adding a newline, we just check that our desired level
     // is enabled before trying to print.
-    if (project.getLogger().isEnabled(LogLevel.LIFECYCLE)) {
+    if (logger.isEnabled(LogLevel.LIFECYCLE)) {
       System.out.print(rawString);
     }
   }


### PR DESCRIPTION
- Replace project with injected FileOperations object
- Replace project with logger as that's the only thing used

Fixes part of GoogleCloudPlatform/appengine-plugins#997 issue

Test: existing tests pass