### PR TITLE
ci: fix kokoro windows build script

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -1,8 +1,7 @@
 @echo on
 
-REM Java 9 does not work with our build at the moment, so force java 8
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set PATH=%JAVA_HOME%\bin;%PATH%
+REM Use Java 8 for build
+echo %JAVA_HOME%
 
 cd github/app-gradle-plugin
 


### PR DESCRIPTION
This is a similar Kokoro migration patch as https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/912 and https://github.com/GoogleCloudPlatform/app-maven-plugin/pull/488.

Logs the new environment's default `JAVA_HOME` (current default: Java 8), and removes the previously set location to resolve build error.