### PR TITLE
chore: update java version for kokoro windows

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -1,7 +1,7 @@
 @echo on
 
 REM Java 9 does not work with our build at the moment, so force java 8
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
+set JAVA_HOME=c:\program files\java\jdk1.8.0_211
 set PATH=%JAVA_HOME%\bin;%PATH%
 
 cd github/app-gradle-plugin


### PR DESCRIPTION
New `win2019` image uses `jdk1.8.0_211`

