### PR TITLE
Upgrade appengine-plugins-core 0.10.0

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-java@v2
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{ matrix.java }}
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17, 21]
     env:
       CLOUDSDK_CORE_DISABLE_USAGE_REPORTING: true
       CLOUDSDK_CORE_DISABLE_PROMPTS: true
@@ -22,8 +22,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 21]
+        java: [8, 11]
     env:
       CLOUDSDK_CORE_DISABLE_USAGE_REPORTING: true
       CLOUDSDK_CORE_DISABLE_PROMPTS: true
@@ -22,9 +22,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v1
         with:
-          distribution: zulu
           java-version: ${{ matrix.java }}
       - uses: actions/cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## 2.4.6-SNAPSHOT
 
+* Update to appengine-plugins-core 0.10.0 that supports GAE Java21 runtime.
+
 ## 2.4.5
 ### Changed
 * Update to appengine-plugins-core 0.9.9, for automatic Java 17 compatibility when running local devserver [appengine-plugins-core#894](https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/894).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 2.4.6-SNAPSHOT
 
-* Update to appengine-plugins-core 0.10.0 that supports GAE Java21 runtime.
+* Update to appengine-plugins-core 0.10.0 that supports GAE java17 and java21 runtimes.
 
 ## 2.4.5
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ group = "com.google.cloud.tools"
 dependencies {
   implementation(localGroovy())
   implementation(gradleApi())
-  api("com.google.cloud.tools:appengine-plugins-core:0.9.9")
+  api("com.google.cloud.tools:appengine-plugins-core:0.10.0")
 
   testImplementation("commons-io:commons-io:2.11.0")
   testImplementation("junit:junit:4.13.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,18 @@ tasks.withType<JavaCompile>().configureEach {
     )
 }
 
+// Gradle 6 needs a special treatment for Guava 31+; otherwise you get "... However we
+// cannot choose between the following variants..." error.
+// https://github.com/google/guava/releases/tag/v32.1.0
+sourceSets.all {
+  configurations.getByName(runtimeClasspathConfigurationName) {
+    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String::class.java), "standard-jvm")
+  }
+  configurations.getByName(compileClasspathConfigurationName) {
+    attributes.attribute(Attribute.of("org.gradle.jvm.environment", String::class.java), "standard-jvm")
+  }
+}
+
 /* TESTING */
 tasks.test.configure {
   testLogging {


### PR DESCRIPTION
# How to reproduce the Guava Gradle error

```
$ gh pr checkout 462
$ ./gradlew build
```

You get the error:

```
> Task :compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.google.guava:guava:32.1.2-jre.
     Required by:
         project : > com.google.cloud.tools:appengine-plugins-core:0.10.0
      > The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, and its dependencies declared externally. However we cannot choose between the following variants of com.google.guava:guava:32.1.2-jre:
          - androidApiElements
          - jreApiElements
        All of them match the consumer attributes:
          - Variant 'androidApiElements' capabilities com.google.collections:google-collections:32.1.2-jre and com.google.guava:guava:32.1.2-jre declares an API of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally:
              - Unmatched attributes:
                  - Provides attribute 'org.gradle.jvm.environment' with value 'android' but the consumer didn't ask for it
                  - Provides release status but the consumer didn't ask for it
          - Variant 'jreApiElements' capabilities com.google.collections:google-collections:32.1.2-jre and com.google.guava:guava:32.1.2-jre declares an API of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally:
              - Unmatched attributes:
                  - Provides attribute 'org.gradle.jvm.environment' with value 'standard-jvm' but the consumer didn't ask for it
                  - Provides release status but the consumer didn't ask for it

```